### PR TITLE
LGA-3206: Add environment parameter to Sentry

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,7 +26,11 @@ if Config.SENTRY_DSN:
         # of sampled transactions.
         # We recommend adjusting this value in production.
         profiles_sample_rate=0.2,
+        # This can either be dev, uat, staging, or production.
+        # It is set by CLA_ENVIRONMENT in the helm charts.
+        environment=Config.ENVIRONMENT,
     )
+
 
 def create_app(config_class=Config):
     app = Flask(__name__, static_url_path="/assets")

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -6,6 +6,7 @@ load_dotenv()
 
 
 class Config(object):
+    ENVIRONMENT = os.environ.get("CLA_ENVIRONMENT", "production")
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "")
     DEPARTMENT_NAME = os.environ.get("DEPARTMENT_NAME", "MOJ Digital")

--- a/helm_deploy/laa-access-civil-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/laa-access-civil-legal-aid/templates/_helpers.tpl
@@ -66,6 +66,8 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "laa-access-civil-legal-aid.app.vars" -}}
+- name: CLA_ENVIRONMENT
+  value: {{.Values.environment}}
 {{ range $name, $data := .Values.envVars }}
 - name: {{ $name }}
 {{- if $data.value }}

--- a/helm_deploy/laa-access-civil-legal-aid/values/values-dev.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-dev.yaml
@@ -1,5 +1,5 @@
 # Default values for laa-access-civil-legal-aid in the dev environment.
-# The laa-access-civil-legal-aid-dev namespace installs an new helm release per feature branch
+# The laa-access-civil-legal-aid-dev namespace installs a new helm release per feature branch
 # this is then uninstalled when the branch is merged.
 environment: "dev"
 


### PR DESCRIPTION
## What does this pull request do?

Adds the `CLA_ENVIRONMENT` variable to Config and Sentry.

This environment variable is defined from the values file in the Helm chart.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
