### PR TITLE
Use app_context_processor for context_processors that should be appli…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,6 @@ from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
 from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
-from app.main.gtm import get_gtm_anon_id
 from app.main import get_locale
 import sentry_sdk
 
@@ -149,8 +148,6 @@ def create_app(config_class=Config):
 
     # Register blueprints
     from app.main import bp as main_bp
-
-    main_bp.context_processor(get_gtm_anon_id)
 
     app.register_blueprint(main_bp)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
 from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
+from app.main.gtm import get_gtm_anon_id
 from app.main import get_locale
 import sentry_sdk
 
@@ -148,6 +149,8 @@ def create_app(config_class=Config):
 
     # Register blueprints
     from app.main import bp as main_bp
+
+    main_bp.app_context_processor(get_gtm_anon_id)
 
     app.register_blueprint(main_bp)
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -16,7 +16,7 @@ def get_locale():
     return request.accept_languages.best_match(language_keys) or "en"
 
 
-@bp.context_processor
+@bp.app_context_processor
 def inject_language_switcher():
     locale = get_locale()
     code = "cy" if locale == "en" else "en"

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -5,6 +5,7 @@ import uuid
 import re
 
 
+@bp.app_context_processor
 def get_gtm_anon_id():
     gtm_anon_id = session.get("gtm_anon_id", "")
     return {"gtm_anon_id": gtm_anon_id}

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -5,7 +5,6 @@ import uuid
 import re
 
 
-@bp.app_context_processor
 def get_gtm_anon_id():
     gtm_anon_id = session.get("gtm_anon_id", "")
     return {"gtm_anon_id": gtm_anon_id}


### PR DESCRIPTION
## What does this pull request do?

- Switches Blueprint scoped `context_processors` to `app_context_processors`.
- - At this stage all context processors should be applied globally.

## Any other changes that would benefit highlighting?

- `get_gtm_anon_id` now uses the function decorator syntax for consistency.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
