### PR TITLE
LGA-3336 - Use a cron job to update the trivy vulnerability db

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -52,3 +52,6 @@ jobs:
           ignore-unfixed: false
           vuln-type: 'os,library'
           severity: 'UNKNOWN,LOW,MEDIUM,CRITICAL,HIGH'
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true

--- a/.github/workflows/trivy-cron.yml
+++ b/.github/workflows/trivy-cron.yml
@@ -1,0 +1,39 @@
+# Note: This workflow only updates the cache. You should create a separate workflow for your actual Trivy scans.
+# In your scan workflow, set TRIVY_SKIP_DB_UPDATE=true and TRIVY_SKIP_JAVA_DB_UPDATE=true.
+name: Update Trivy Cache
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}

--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   trivy-image-scan:
+    name: Trivy Image Scan
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
## What does this pull request do?

Use a cron job to update the trivy vulnerability db.

## Any other changes that would benefit highlighting?

This sets up a cron job to regularly update the cache in the default branch. This allows subsequent scans to use the cached DB without downloading it again

Based on https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#updating-caches-in-the-default-branch

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
