### PR TITLE
LGA-3347 Add housing category

### DIFF
--- a/app/categories/__init__.py
+++ b/app/categories/__init__.py
@@ -1,9 +1,12 @@
 from flask import Blueprint
 from .domestic_abuse import bp as domestic_abuse_bp
 from .discrimination import bp as discrimination_bp
+from .housing import bp as housing_bp
+
 
 bp = Blueprint("categories", __name__)
 bp.register_blueprint(domestic_abuse_bp)
 bp.register_blueprint(discrimination_bp)
+bp.register_blueprint(housing_bp)
 
 from app.categories import routes  # noqa: E402,F401

--- a/app/categories/housing/__init__.py
+++ b/app/categories/housing/__init__.py
@@ -1,0 +1,10 @@
+from flask import Blueprint
+
+bp = Blueprint(
+    "housing",
+    __name__,
+    template_folder="./templates",
+    url_prefix="/housing",
+)
+
+from app.categories.housing import routes  # noqa: E402,F401

--- a/app/categories/housing/routes.py
+++ b/app/categories/housing/routes.py
@@ -1,0 +1,50 @@
+from app.categories.housing import bp
+from flask import render_template, url_for
+
+
+@bp.route("")
+def index():
+    return render_template(
+        "categories/housing/index.html",
+        back_link=url_for("categories.index"),
+    )
+
+
+@bp.route("/homelessness")
+def homelessness():
+    return render_template(
+        "categories/housing/homelessness.html",
+        back_link=url_for("categories.housing.index"),
+    )
+
+
+@bp.route("/eviction-told-to-leave-your-home")
+def eviction():
+    return render_template(
+        "categories/housing/eviction.html",
+        back_link=url_for("categories.housing.index"),
+    )
+
+
+@bp.route("/forced-to-sell-losing-home-you-own")
+def forced_sale():
+    return render_template(
+        "categories/housing/forced-sale.html",
+        back_link=url_for("categories.housing.index"),
+    )
+
+
+@bp.route("/repairs-health-and-safety")
+def repairs():
+    return render_template(
+        "categories/housing/repairs.html",
+        back_link=url_for("categories.housing.index"),
+    )
+
+
+@bp.route("/problems-with-council-housing")
+def council_housing():
+    return render_template(
+        "categories/housing/council-housing.html",
+        back_link=url_for("categories.housing.index"),
+    )

--- a/app/templates/categories/components/cannot-find-your-problem.html
+++ b/app/templates/categories/components/cannot-find-your-problem.html
@@ -1,0 +1,6 @@
+{% macro cannot_find_your_problem(category, link) -%}
+    <div class="govuk-inset-text">
+        <p class="govuk-heading-s">{% trans %}If you cannot find your problem{% endtrans %}: {{ category }}</p>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">Next steps to get help</a>
+    </div>
+{% endmacro %}

--- a/app/templates/categories/housing/council-housing.html
+++ b/app/templates/categories/housing/council-housing.html
@@ -1,0 +1,27 @@
+{# This page was built as a prototype #}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
+{%- from 'categories/components/list-item.html' import list_item, list_item_small -%}
+
+{% block pageTitle %}{% trans %}Housing {% endtrans %} - {% trans %}GOV.UK{% endtrans %}{% endblock %}
+
+{% block beforeContent%}
+{{ super() }}
+{{ govukBackLink({
+    'href': url_for('categories.housing.index'),
+    'text': "Back"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+<h2>Delete me and replace with a session store and redirect to means</h2>
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{% trans %}Problems with council housing{% endtrans %}</h1>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/categories/housing/eviction.html
+++ b/app/templates/categories/housing/eviction.html
@@ -1,0 +1,28 @@
+{# This page was built as a prototype #}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
+{%- from 'categories/components/list-item.html' import list_item, list_item_small -%}
+
+{% block pageTitle %}{% trans %}Housing {% endtrans %} - {% trans %}GOV.UK{% endtrans %}{% endblock %}
+
+{% block beforeContent%}
+{{ super() }}
+{{ govukBackLink({
+    'href': url_for('categories.housing.index'),
+    'text': "Back"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+    <h2>Delete me and replace with a session store and redirect to means</h2>
+
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{% trans %}Eviction, told to leave your home{% endtrans %}</h1>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/categories/housing/forced-sale.html
+++ b/app/templates/categories/housing/forced-sale.html
@@ -1,0 +1,27 @@
+{# This page was built as a prototype #}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
+{%- from 'categories/components/list-item.html' import list_item, list_item_small -%}
+
+{% block pageTitle %}{% trans %}Housing {% endtrans %} - {% trans %}GOV.UK{% endtrans %}{% endblock %}
+
+{% block beforeContent%}
+{{ super() }}
+{{ govukBackLink({
+    'href': url_for('categories.housing.index'),
+    'text': "Back"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+<h2>Delete me and replace with a session store and redirect to means</h2>
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{% trans %}Forced to sell or losing the home you own{% endtrans %}</h1>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/categories/housing/homelessness.html
+++ b/app/templates/categories/housing/homelessness.html
@@ -1,0 +1,27 @@
+{# This page was built as a prototype #}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
+{%- from 'categories/components/list-item.html' import list_item, list_item_small -%}
+
+{% block pageTitle %}{% trans %}Housing {% endtrans %} - {% trans %}GOV.UK{% endtrans %}{% endblock %}
+
+{% block beforeContent%}
+{{ super() }}
+{{ govukBackLink({
+    'href': url_for('categories.housing.index'),
+    'text': "Back"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+<h2>Delete me and replace with a session store and redirect to means</h2>
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{% trans %}Homelessness{% endtrans %}</h1>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/categories/housing/index.html
+++ b/app/templates/categories/housing/index.html
@@ -1,0 +1,74 @@
+{# This page was built as a prototype #}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
+{%- from 'categories/components/list-item.html' import list_item, list_item_small -%}
+{%- from 'categories/components/cannot-find-your-problem.html' import cannot_find_your_problem -%}
+
+{% block pageTitle %}Domestic Abuse - GOV.UK{% endblock %}
+
+{% block beforeContent%}
+{{ super() }}
+{{ govukBackLink({
+    'href': url_for('categories.index'),
+    'text': "Back"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{% trans %}Housing, homelessness, losing your home{% endtrans %}</h1>
+
+        <br>
+
+        {{ list_item(_("Homelessness"),
+                     _("Help if you’re homeless, or might be homeless in the next 2 months. This could be because of rent arrears, debt, the end of a relationship, or because you have nowhere to live."),
+                     url_for("categories.housing.homelessness")) }}
+
+        {{ list_item(_("Eviction, told to leave your home"),
+             _("Landlord has told you to leave or is trying to force you to leave. Includes if you’ve got a Section 21 or a possession order."),
+             url_for("categories.housing.eviction")) }}
+
+        {{ list_item(_("Forced to sell or losing the home you own"),
+             _("Repossession by your mortgage company; bankruptcy or other debt that means you will lose the home you own."),
+             url_for("categories.housing.forced_sale")) }}
+
+            {{ list_item(_("Repairs, health and safety"),
+                     _("If your house is not safe to live in, or needs repairs, and this is causing health or safety problems."),
+                     url_for("categories.housing.repairs")) }}
+
+        {{ list_item(_("Problems with council housing"),
+             _("Help to challenge the council’s decision about giving you housing. It includes if the council has offered a house that is not right for you, or that needs repairs or adaptations."),
+             url_for("categories.housing.council_housing")) }}
+        <br>
+
+        <h2 class="govuk-heading-m">{%  trans%}Other problems{% endtrans %}</h2>
+
+        <br>
+
+        {{ list_item_small(_("Being threatened or harassed where you live"),
+                           _("By a landlord, neighbour or someone else."),
+                            url_for("categories.index")) }}
+
+        {{ list_item_small(_("If you’re an asylum-seeker"),
+                   _("Applying for housing, losing your housing or homelessness."),
+                    url_for("categories.index")) }}
+
+            {{ list_item_small(_("Discrimination"),
+                   _("Treated unfairly by a landlord, council or housing association"),
+                    url_for("categories.index")) }}
+
+                {{ list_item_small(_("If you’ve been accused of anti-social behaviour"),
+                   _("Accused of anti-social behaviour by the landlord, council or housing association."),
+                    url_for("categories.index")) }}
+            <br>
+            <br>
+            {{ cannot_find_your_problem("housing", "/scope/refer/housing")}}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/categories/housing/repairs.html
+++ b/app/templates/categories/housing/repairs.html
@@ -1,0 +1,27 @@
+{# This page was built as a prototype #}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
+{%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
+{%- from 'categories/components/list-item.html' import list_item, list_item_small -%}
+
+{% block pageTitle %}{% trans %}Housing {% endtrans %} - {% trans %}GOV.UK{% endtrans %}{% endblock %}
+
+{% block beforeContent%}
+{{ super() }}
+{{ govukBackLink({
+    'href': url_for('categories.housing.index'),
+    'text': "Back"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+<h2>Delete me and replace with a session store and redirect to means</h2>
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{% trans %}Repairs, health and safety{% endtrans %}</h1>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/categories/index.html
+++ b/app/templates/categories/index.html
@@ -33,7 +33,7 @@
 
             {{ list_item_arrow("Housing, homelessness, losing your home",
                  "Includes being evicted or forced to sell your home. Problems with landlords, repairs, neighbours or council housing.",
-                 url_for("categories.index")) }}
+                 url_for("categories.housing.index")) }}
 
             {{ list_item_arrow("Asylum and immigration",
                  "Help if you’re seeking asylum. Help to stay in the UK if you experienced domestic abuse.",


### PR DESCRIPTION
## What does this pull request do?

Add housing category.

## Any other changes that would benefit highlighting?

The following templates are placeholders and instead will need to be removed. Instead of rendering a template the new strategy is to store the scope steps into the session and then redirect to the means. However that work is not ready yet so we have these temporary placeholders

- app/templates/categories/housing/council-housing.html
- app/templates/categories/housing/eviction.html
- app/templates/categories/housing/forced-sale.html
- app/templates/categories/housing/homelessness.html
- app/templates/categories/housing/repairs.html

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
