### PR TITLE
Fix: Rename other problems to more problems

### DIFF
--- a/app/templates/categories/domestic_abuse/landing.html
+++ b/app/templates/categories/domestic_abuse/landing.html
@@ -42,7 +42,7 @@
 
         <br>
 
-        <h2 class="govuk-heading-m">More problems</h2>
+        <h2 class="govuk-heading-m">{% trans %}More problems{% endtrans %}</h2>
 
         <br>
 

--- a/app/templates/categories/domestic_abuse/landing.html
+++ b/app/templates/categories/domestic_abuse/landing.html
@@ -42,7 +42,7 @@
 
         <br>
 
-        <h2 class="govuk-heading-m">Other problems</h2>
+        <h2 class="govuk-heading-m">More problems</h2>
 
         <br>
 

--- a/app/templates/categories/housing/landing.html
+++ b/app/templates/categories/housing/landing.html
@@ -44,7 +44,7 @@
              url_for("categories.housing.council_housing")) }}
         <br>
 
-        <h2 class="govuk-heading-m">{%  trans%}Other problems{% endtrans %}</h2>
+        <h2 class="govuk-heading-m">{%  trans%}More problems{% endtrans %}</h2>
 
         <br>
 


### PR DESCRIPTION
## What does this pull request do?

Fixes a deviation from the content record where "More problems" was erroneously named "Other problems" on two category landing pages.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
