### PR TITLE
Feature/lga 3261 enable modsec

### DIFF
--- a/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
@@ -22,6 +22,9 @@ metadata:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}

--- a/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
@@ -25,6 +25,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-get-access"
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}

--- a/helm_deploy/laa-access-civil-legal-aid/values.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values.yaml
@@ -37,7 +37,7 @@ service:
 
 ingress:
   enabled: true
-  className: "default"
+  className: "modsec"
   annotations: {}
   cluster:
     name: green


### PR DESCRIPTION
## What does this pull request do?

Adds in and enables modsecurity on the ingress of Access.

Tested with the below url on dev https://lga-3261-enable-modsec-access-cla.cloud-platform.service.justice.gov.uk/index.php?file=../../../../etc/passwd
<img width="1263" alt="Screenshot 2024-12-04 at 14 52 15" src="https://github.com/user-attachments/assets/526860a2-cb0a-4531-9103-ef13d2f477cc">

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

[- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"](https://dsdmoj.atlassian.net/browse/LGA-3261)
