### PR TITLE
LGA-3368: Include custom images

### DIFF
--- a/app/static/src/images/action-link-arrow--simple.svg
+++ b/app/static/src/images/action-link-arrow--simple.svg
@@ -1,0 +1,4 @@
+<svg width="23" height="23" viewBox="0 0 23 23" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M14.9429 11.7949L10.4402 7.29222L11.7327 5.99967L17.528 11.7949L11.7327 17.5902L10.4402 16.2976L14.9429 11.7949Z" fill="#272828"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.95631 10.881L15.4414 10.881L15.4414 12.709L3.95631 12.709L3.95631 10.881Z" fill="#272828"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   },
   "scripts": {
     "gov-images": "cp -R node_modules/govuk-frontend/dist/govuk/assets/. app/static/dist",
-    "build": "npm run gov-images && node esbuild.config.js",
+    "copy-images": "cp -R app/static/src/images/. app/static/dist/images && npm run gov-images",
+    "build": "npm run copy-images && node esbuild.config.js",
     "watch": "npm run gov-images && node esbuild.config.js --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "scripts": {
     "gov-images": "cp -R node_modules/govuk-frontend/dist/govuk/assets/. app/static/dist",
-    "copy-images": "cp -R app/static/src/images/. app/static/dist/images && npm run gov-images",
+    "copy-images": "npm run gov-images && cp -R app/static/src/images/. app/static/dist/images",
     "build": "npm run copy-images && node esbuild.config.js",
     "watch": "npm run gov-images && node esbuild.config.js --watch"
   },


### PR DESCRIPTION
## What does this pull request do?

- Builds custom images by copying files found in `src/images` to `dist/images`.
- Adds the new arrow icon image

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
