### PR TITLE
Add logic to make fields conditional using govuk-frontend conditional logic

### DIFF
--- a/app/means_test/forms/__init__.py
+++ b/app/means_test/forms/__init__.py
@@ -15,3 +15,18 @@ class BaseMeansTestForm(FlaskForm):
     @classmethod
     def should_show(cls) -> bool:
         return True
+
+    def render_conditional(self, field, sub_field, conditional_value) -> str:
+        """
+        Make field conditional using govuk-frontend conditional logic
+
+        :param field: The controlling field
+        :param sub_field: The controlled field
+        :param conditional_value: The value the controlling field should have to show the controlled field
+        :return str: The render field and subfield:
+        """
+
+        sub_field_rendered = sub_field()
+        conditional = {"value": conditional_value, "html": sub_field_rendered}
+        field.render_kw = {"conditional": conditional}
+        return field()

--- a/app/means_test/widgets.py
+++ b/app/means_test/widgets.py
@@ -45,9 +45,23 @@ class MeansTestInputField:
         return params
 
 
-class MeansTestRadioInput(MeansTestInputField, GovRadioInput):
+class RenderConditionalFields:
+    def map_gov_params(self, field, **kwargs):
+        params = super().map_gov_params(field, **kwargs)
+
+        if "conditional" in kwargs:
+            conditional = kwargs.pop("conditional")
+            for item in params["items"]:
+                if item["value"] == conditional["value"]:
+                    item["conditional"] = {"html": conditional["html"]}
+        return params
+
+
+class MeansTestRadioInput(MeansTestInputField, RenderConditionalFields, GovRadioInput):
     pass
 
 
-class MeansTestCheckboxInput(MeansTestInputField, GovCheckboxesInput):
+class MeansTestCheckboxInput(
+    MeansTestInputField, RenderConditionalFields, GovCheckboxesInput
+):
     pass


### PR DESCRIPTION
## What does this pull request do?

Add logic to make fields conditional using govuk-frontend conditional logic

## Any other changes that would benefit highlighting?

### Usage
In your template do: `{{ form.render_conditional(form.field, form.sub_field, conditional_value) }}`

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
