### PR TITLE
Add new MoneyInterval helper class

### DIFF
--- a/app/means_test/fields.py
+++ b/app/means_test/fields.py
@@ -3,6 +3,7 @@ from wtforms.widgets import TextInput
 from markupsafe import Markup
 from wtforms import Field
 from flask_babel import lazy_gettext as _
+from app.means_test.money_interval import MoneyInterval
 
 
 class MoneyFieldWidgetWidget(TextInput):
@@ -44,6 +45,14 @@ class MoneyField(Field):
             )
         return choices
 
+    @property
+    def interval(self):
+        return self.data["interval_period"]
+
+    @property
+    def value(self):
+        return self.data["per_interval_value_pounds"]
+
     def __init__(
         self,
         label=None,
@@ -55,30 +64,31 @@ class MoneyField(Field):
         super().__init__(label, validators, **kwargs)
         self.title = label
         self.hint = hint_text
-        self.value = None  # Amount
-        self.interval = None  # Frequency
         self.field_with_error = []
         self._intervals = self._intervals.copy()
         if exclude_intervals:
             for interval in exclude_intervals:
                 del self._intervals[interval]
 
+    @property
+    def data(self):
+        if self._data is None:
+            instance = MoneyInterval()
+        elif isinstance(self._data, MoneyInterval):
+            instance = self._data
+        else:
+            instance = MoneyInterval(self._data)
+        return instance.to_json()
+
+    @data.setter
+    def data(self, data):
+        self._data = data
+
     def process_formdata(self, valuelist):
         """Process the form data from both inputs"""
         if valuelist and len(valuelist) == 2:
             # Handle the data coming from the form fields named field.id[value] and field.id[interval]
-            self.value = valuelist[0]
-            self.interval = valuelist[1]
-
-    def validate(self, form, extra_validators=None):
-        if self.interval not in self._intervals:
-            raise ValueError(
-                f"Invalid {self.interval} interval value given for field {self.name}"
-            )
-        return super().validate(form, extra_validators)
-
-    def _value(self):
-        if self.raw_data:
-            return " ".join(self.raw_data)
-        else:
-            return self.data and self.data.strftime(self.format) or ""
+            self.data = valuelist
+        elif valuelist and len(valuelist) == 1 and isinstance(valuelist[0], dict):
+            # Data being restored from the session
+            self.data = valuelist[0]

--- a/app/means_test/money_interval.py
+++ b/app/means_test/money_interval.py
@@ -1,0 +1,141 @@
+from decimal import Decimal, InvalidOperation
+from flask_babel import lazy_gettext as _
+
+
+def to_amount(value):
+    amount = None
+
+    if value is None:
+        amount = None
+
+    elif isinstance(value, str):
+        amount = to_amount(Decimal(value.replace(",", "").replace(" ", "")))
+
+    elif isinstance(value, float):
+        amount = int(value * 100)
+
+    elif isinstance(value, Decimal):
+        amount = int(value * 100)
+
+    else:
+        amount = int(value)
+
+    return amount
+
+
+class MoneyInterval(dict):
+    # interval_name, user_copy_name, multiply_factor (to get monthly value)
+    _intervals = {
+        "per_week": {"label": _("per week"), "multiply_factor": 52.0 / 12.0},
+        "per_2week": {"label": _("2 weekly"), "multiply_factor": 26.0 / 12.0},
+        "per_4week": {"label": _("4 weekly"), "multiply_factor": 13.0 / 12.0},
+        "per_month": {"label": _("per month"), "multiply_factor": 1.0},
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(MoneyInterval, self).__init__(
+            {"per_interval_value": None, "interval_period": None}
+        )
+
+        if len(args) > 0:
+            value = args[0]
+            if isinstance(value, MoneyInterval):
+                self.amount = value.amount
+                self.interval = value.interval
+            elif isinstance(value, dict):
+                self.amount = value.get("per_interval_value")
+                if "interval_period" in value:
+                    interval = value.get("interval_period")
+                    if interval:
+                        self.interval = interval
+            elif isinstance(value, list):
+                if value[0]:
+                    self.amount = value[0]
+                if value[1]:
+                    self.interval = value[1]
+            else:
+                self.amount = value
+
+        else:
+            self.amount = kwargs.get("per_interval_value")
+            self.interval = kwargs.get("interval_period")
+
+    @property
+    def amount(self):
+        return self.get("per_interval_value")
+
+    @amount.setter
+    def amount(self, value):
+        """
+        Assumes integer is amount in pence, float or Decimal is amount in
+        pounds and first 2 decimal places are pence. String is converted to
+        Decimal first.
+        """
+
+        try:
+            self["per_interval_value"] = to_amount(value)
+
+        except (InvalidOperation, ValueError):
+            raise ValueError(
+                "Invalid value for amount {0} ({1})".format(value, type(value))
+            )
+
+    def amount_to_pounds(self):
+        if not self["per_interval_value"]:
+            return None
+        return self["per_interval_value"] / 100
+
+    @property
+    def interval(self):
+        return self.get("interval_period")
+
+    @interval.setter
+    def interval(self, value):
+        if value:
+            if value in MoneyInterval._intervals:
+                self["interval_period"] = value
+            else:
+                raise ValueError(value)
+
+    def per_month(self):
+        if self.amount is None or self.interval == "":
+            return MoneyInterval(0)
+
+        if self.interval == "per_month":
+            return self
+
+        multiplier = self._intervals[self.interval]["multiply_factor"]
+
+        return MoneyInterval(int(self.amount * multiplier))
+
+    def to_json(self):
+        return {
+            "per_interval_value": self.amount,
+            "per_interval_value_pounds": self.amount_to_pounds(),
+            "interval_period": self.interval,
+        }
+
+    def __add__(self, other):
+        if other == 0:
+            other = MoneyInterval(0)
+
+        if not isinstance(other, MoneyInterval):
+            if self.is_money_interval(other):
+                other = MoneyInterval(other)
+            else:
+                raise ValueError(other)
+
+        first = self.per_month()
+        second = other.per_month()
+
+        return MoneyInterval(first.amount + second.amount)
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    @classmethod
+    def is_money_interval(cls, other):
+        if hasattr(other, "keys") and callable(other.keys):
+            keys = set(other.keys())
+            return keys == set(["per_interval_value", "interval_period"])
+        return False

--- a/app/means_test/validators.py
+++ b/app/means_test/validators.py
@@ -1,5 +1,11 @@
+from enum import Enum
 from flask import session
 from wtforms.validators import StopValidation
+
+
+class ValidateIfType(Enum):
+    IN: str = lambda x, items: x in items
+    EQ: str = lambda a, b: a == b
 
 
 class ValidateIf:
@@ -7,9 +13,11 @@ class ValidateIf:
         self,
         dependent_field_name: str,
         dependent_field_value,
+        condition_type: ValidateIfType = ValidateIfType.EQ,
     ):
         self.dependent_field_name: str = dependent_field_name
         self.dependent_field_value = dependent_field_value
+        self.condition_type: ValidateIfType = condition_type
 
     def __call__(self, form, field):
         other_field = form._fields.get(self.dependent_field_name)
@@ -17,7 +25,8 @@ class ValidateIf:
             raise ValueError('no field named "%s" in form' % self.dependent_field_name)
 
         # If the dependent field doesn't match the value, skip validation
-        if other_field.data != self.dependent_field_value:
+        match = self.condition_type(self.dependent_field_value, other_field.data)
+        if not match:
             field.errors = []
             raise StopValidation()
 

--- a/tests/unit_tests/means_test/test_money_interval.py
+++ b/tests/unit_tests/means_test/test_money_interval.py
@@ -1,0 +1,49 @@
+from app.means_test.money_interval import MoneyInterval
+
+
+def test_money_interval():
+    instance = MoneyInterval(["100", "per_week"])
+    assert instance.amount == 10000
+    assert instance.amount_to_pounds() == 100
+
+    factor = 52.0 / 12.0
+    expected_monthly_amount = 10000 * factor
+    assert instance.per_month()["per_interval_value"] == int(expected_monthly_amount)
+
+
+def test_money_interval_with_pence():
+    instance = MoneyInterval(["25.50", "per_week"])
+    assert instance.amount == 2550
+    assert instance.amount_to_pounds() == 25.50
+
+
+def test_money_interval_addition_per_week():
+    """Add  per week and per month intervals"""
+    first_amount_pounds = 100
+    first_amount_pence = 10000
+    second_amount_pounds = 200
+    second_amount_pence = 20000
+    instance = MoneyInterval([str(first_amount_pounds), "per_week"]) + {
+        "per_interval_value": str(second_amount_pounds),
+        "interval_period": "per_month",
+    }
+    factor = 52.0 / 12.0
+    expected_monthly_amount = (
+        int(int(first_amount_pence) * factor) + second_amount_pence
+    )
+    assert instance.amount == expected_monthly_amount
+
+
+def test_money_interval_addition_per_month():
+    """Add two per month intervals"""
+    first_amount_pounds = 100
+    first_amount_pence = 10000
+    second_amount_pounds = 200
+    second_amount_pence = 20000
+    instance = MoneyInterval([str(first_amount_pounds), "per_month"]) + {
+        "per_interval_value": str(second_amount_pounds),
+        "interval_period": "per_month",
+    }
+    factor = 1.0
+    expected_monthly_amount = int(first_amount_pence * factor) + second_amount_pence
+    assert instance.amount == expected_monthly_amount


### PR DESCRIPTION
## What does this pull request do?
Add new MoneyInterval helper class
Make MoneyField.data return the MoneyInterval.to_json because flask will not be able to serialise a MoneyInterval object This means that MoneyInterval.to_json can be used as payload to send to the backend for any MoneyField fields

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
