### PR TITLE
Fix Money field hint text

### DIFF
--- a/app/means_test/fields.py
+++ b/app/means_test/fields.py
@@ -63,7 +63,7 @@ class MoneyField(Field):
     ):
         super().__init__(label, validators, **kwargs)
         self.title = label
-        self.hint = hint_text
+        self.hint_text = hint_text
         self.field_with_error = []
         self._intervals = self._intervals.copy()
         if exclude_intervals:

--- a/app/templates/means_test/components/money-field.html
+++ b/app/templates/means_test/components/money-field.html
@@ -18,9 +18,11 @@
               {{ field.title }}
           </h1>
         </legend>
-         <div id="passport-issued-hint" class="govuk-hint">
-            {{ field.hint }}
+        {% if field.hint_text %}
+         <div class="govuk-hint">
+            {{ field.hint_text }}
         </div>
+        {% endif %}
         {{ renderError(field.field_with_error) }}
         <div class="govuk-grid-row" class="govuk-form-group {% if field.errors %}govuk-form-group--error{% endif %}">
             <div class="govuk-grid-column-one-half">

--- a/app/templates/means_test/components/money-field.html
+++ b/app/templates/means_test/components/money-field.html
@@ -12,7 +12,7 @@
 {% endmacro %}
 
 <div class="govuk-form-group {%- if field.errors %} govuk-form-group--error{% endif %}">
-    <fieldset class="govuk-fieldset" role="group" id="question">
+    <fieldset class="govuk-fieldset" role="group" id={{ field.name }}>
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
           <h1 class="govuk-fieldset__heading">
               {{ field.title }}


### PR DESCRIPTION
## What does this pull request do?

- Fixes Money Field hint text
- Gives the Money Field the correct ID so it can be scrolled to when clicking an error message

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
