### PR TITLE
Create a custom IntegerField that allows None as a formdata value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: requirements-(base|production).in
         args: [requirements/source/requirements-production.in, "--output-file", requirements/generated/requirements-production.txt, "--no-annotate"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.2
+    rev: v0.9.3
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/app/means_test/fields.py
+++ b/app/means_test/fields.py
@@ -2,7 +2,7 @@ from flask import render_template
 from flask_babel import lazy_gettext as _
 from wtforms.widgets import TextInput
 from markupsafe import Markup
-from wtforms import Field
+from wtforms import Field, IntegerField as BaseIntegerField
 from app.means_test.money_interval import MoneyInterval
 
 
@@ -85,3 +85,12 @@ class MoneyIntervalField(Field):
         elif valuelist and len(valuelist) == 1 and isinstance(valuelist[0], dict):
             # Data being restored from the session
             self.data = valuelist[0]
+
+
+class IntegerField(BaseIntegerField):
+    def process_formdata(self, valuelist):
+        """The parent method will fail when it tries to convert a None to an Integer"""
+        if not valuelist or valuelist[0] is None:
+            return
+
+        super().process_formdata(valuelist)

--- a/app/means_test/forms/about_you.py
+++ b/app/means_test/forms/about_you.py
@@ -1,4 +1,4 @@
-from wtforms.fields import RadioField, IntegerField
+from wtforms.fields import RadioField
 from govuk_frontend_wtf.wtforms_widgets import GovTextInput
 from wtforms.validators import InputRequired, NumberRange
 from app.means_test.validators import ValidateIf
@@ -6,6 +6,7 @@ from app.means_test.widgets import MeansTestRadioInput
 from flask_babel import lazy_gettext as _
 from app.means_test import YES, NO
 from app.means_test.forms import BaseMeansTestForm
+from app.means_test.fields import IntegerField
 
 
 class AboutYouForm(BaseMeansTestForm):
@@ -60,8 +61,6 @@ class AboutYouForm(BaseMeansTestForm):
 
     num_children = IntegerField(
         _("How many?"),
-        # Needs a default value otherwise the IntegerField.process_formdata will throw an exception when it has a None value
-        default=0,
         widget=GovTextInput(),
         validators=[
             ValidateIf("have_children", YES),
@@ -88,8 +87,6 @@ class AboutYouForm(BaseMeansTestForm):
 
     num_dependents = IntegerField(
         _("How many?"),
-        # Needs a default value otherwise the IntegerField.process_formdata will throw an exception when it has a None value
-        default=0,
         widget=GovTextInput(),
         validators=[
             ValidateIf("have_dependents", YES),

--- a/tests/unit_tests/means_test/test_money_field.py
+++ b/tests/unit_tests/means_test/test_money_field.py
@@ -52,6 +52,6 @@ def test_money_field_only_amount_interval(app, client):
 def test_money_field_excluded_interval(app, client):
     data = MultiDict([("money_field", "1000"), ("money_field", "per_month")])
     form = TestForm(formdata=data)
-    assert (
-        not form.validate()
-    ), "Validation should have raised an exception for invalid interval"
+    assert not form.validate(), (
+        "Validation should have raised an exception for invalid interval"
+    )


### PR DESCRIPTION
## What does this pull request do?

Create a custom IntegerField that allows None as a formdata value

## Any other changes that would benefit highlighting?

Without this `wtforms.IntegerField.process_formdata` will raise an exception when some conditional fields like `number of children` don't have a default value as it tries to convert a None to an integer.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
