### PR TITLE
Update MoneyField handling of 0

### DIFF
--- a/app/means_test/api.py
+++ b/app/means_test/api.py
@@ -4,7 +4,6 @@ from app.means_test.forms.income import IncomeForm
 from app.means_test.forms.benefits import BenefitsForm, AdditionalBenefitsForm
 from app.means_test.forms.property import MultiplePropertiesForm
 from app.means_test.money_interval import MoneyInterval
-from tests.unit_tests.means_test.payload.test_cases import EligibilityData
 
 
 def update_means_test(payload):
@@ -29,7 +28,7 @@ def is_eligible(reference):
     return response["is_eligible"]
 
 
-def get_means_test_payload(eligibility_data: EligibilityData) -> dict:
+def get_means_test_payload(eligibility_data) -> dict:
     about = eligibility_data.forms.get("about-you", {})
     savings_form = eligibility_data.forms.get("savings", {})
 

--- a/app/means_test/fields.py
+++ b/app/means_test/fields.py
@@ -8,6 +8,7 @@ from markupsafe import Markup
 from wtforms import Field, IntegerField as BaseIntegerField
 from app.means_test.money_interval import MoneyInterval
 import re
+from app.means_test.validators import CurrencyValidator
 
 
 class MoneyIntervalWidget(TextInput):
@@ -95,6 +96,7 @@ class MoneyIntervalField(Field):
         """Process the form data from both inputs"""
         if valuelist and len(valuelist) == 2:
             # Handle the data coming from the form fields named field.id[value] and field.id[interval]
+            valuelist[0] = CurrencyValidator.clean_input(valuelist[0])
             self.data = valuelist
 
             if (
@@ -108,6 +110,7 @@ class MoneyIntervalField(Field):
                 self.min_val is not None
                 and self.data["per_interval_value"] < self.min_val
             ):
+                self.field_with_error.add("value")
                 raise ValueError(
                     f"Enter a value of more than £{self.min_val / 100:,.2f}"
                 )
@@ -115,6 +118,7 @@ class MoneyIntervalField(Field):
                 self.max_val is not None
                 and self.data["per_interval_value"] > self.max_val
             ):
+                self.field_with_error.add("value")
                 raise ValueError(
                     f"Enter a value of less than £{self.max_val / 100:,.2f}"
                 )

--- a/app/means_test/money_interval.py
+++ b/app/means_test/money_interval.py
@@ -74,6 +74,11 @@ class MoneyInterval(dict):
         Decimal first.
         """
 
+        # If you have an amount of 0 the interval is irrelevant, therefore default to per_month
+        # This allows the user to leave frequency as "--Please select--" and enter 0 for the amount
+        if self.interval is None and value == "0":
+            self.interval = "per_month"
+
         try:
             self["per_interval_value"] = to_amount(value)
 

--- a/app/means_test/validators.py
+++ b/app/means_test/validators.py
@@ -79,6 +79,9 @@ class MoneyIntervalAmountRequired(object):
             field.errors.append(str(e))
             field.field_with_error.add("value")
 
+        if (not amount or amount == "0") and (not interval or interval == ""):
+            return
+
         if (not amount) and (not interval):
             message = messages["message"]
             field.errors.append(message)


### PR DESCRIPTION
## What does this pull request do?

Allows for the moneyfield to be set to 0 and 'please select' if you have no values to input.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
