### PR TITLE
LGA-3558: Child in care routing

### DIFF
--- a/app/categories/send/forms.py
+++ b/app/categories/send/forms.py
@@ -1,16 +1,6 @@
 from app.categories.forms import ChildInCareQuestionForm
-from app.categories.x_cat.forms import AreYouUnder18Form
 from app.categories.constants import EDUCATION
 
 
 class SendChildInCareQuestionForm(ChildInCareQuestionForm):
-    category = EDUCATION
-
-    next_step_mapping = {
-        "yes": "categories.send.age",
-        "no": "categories.send.age",
-    }
-
-
-class SendAreYouUnder18Form(AreYouUnder18Form):
     category = EDUCATION

--- a/app/categories/send/urls.py
+++ b/app/categories/send/urls.py
@@ -1,5 +1,5 @@
 from app.categories.send import bp
-from app.categories.send.forms import SendChildInCareQuestionForm, SendAreYouUnder18Form
+from app.categories.send.forms import SendChildInCareQuestionForm
 from app.categories.views import CategoryLandingPage, QuestionPage
 from app.categories.constants import EDUCATION
 
@@ -30,13 +30,6 @@ bp.add_url_rule(
     view_func=QuestionPage.as_view(
         "child_in_care",
         form_class=SendChildInCareQuestionForm,
-    ),
-)
-bp.add_url_rule(
-    "/send/age",
-    view_func=QuestionPage.as_view(
-        "age",
-        form_class=SendAreYouUnder18Form,
     ),
 )
 

--- a/tests/functional_tests/categories/send/test_send.py
+++ b/tests/functional_tests/categories/send/test_send.py
@@ -3,7 +3,6 @@ import pytest
 
 
 child_in_care_heading = "Is this about a child who is or has been in care?"
-are_you_under_18_page_heading = "Are you under 18?"
 legalaid_available_page = "Legal aid is available for this type of problem"
 contact_page_heading = "Contact us page"
 ROUTING = [
@@ -59,37 +58,13 @@ class TestSendLandingPage:
         page.get_by_role("link", name="SEND tribunals").click()
         page.get_by_label("Yes").check()
         page.get_by_role("button", name="Continue").click()
-        expect(page.get_by_text(are_you_under_18_page_heading)).to_be_visible()
+        expect(page.get_by_text(contact_page_heading)).to_be_visible()
 
     def test_child_in_care_form_no(self, page: Page):
         page.get_by_role(
             "link", name="Special educational needs and disability (SEND)"
         ).click()
         page.get_by_role("link", name="SEND tribunals").click()
-        page.get_by_label("No").check()
-        page.get_by_role("button", name="Continue").click()
-        expect(page.get_by_text(are_you_under_18_page_heading)).to_be_visible()
-
-    def test_are_you_under_18_form_yes(self, page: Page):
-        page.get_by_role(
-            "link", name="Special educational needs and disability (SEND)"
-        ).click()
-        page.get_by_role("link", name="SEND tribunals").click()
-        page.get_by_label("Yes").check()
-        page.get_by_role("button", name="Continue").click()
-        expect(page.get_by_text(are_you_under_18_page_heading)).to_be_visible()
-        page.get_by_label("Yes").check()
-        page.get_by_role("button", name="Continue").click()
-        expect(page.get_by_text(contact_page_heading)).to_be_visible()
-
-    def test_are_you_under_18_form_no(self, page: Page):
-        page.get_by_role(
-            "link", name="Special educational needs and disability (SEND)"
-        ).click()
-        page.get_by_role("link", name="SEND tribunals").click()
-        page.get_by_label("No").check()
-        page.get_by_role("button", name="Continue").click()
-        expect(page.get_by_text(are_you_under_18_page_heading)).to_be_visible()
         page.get_by_label("No").check()
         page.get_by_role("button", name="Continue").click()
         expect(page.get_by_text(legalaid_available_page)).to_be_visible()


### PR DESCRIPTION
## What does this pull request do?

- Removes 'Are you under 18' web form from SEND routing as this question is not part of the routing.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
