### PR TITLE
LGA 3553: Re-create GOV.UK Endpoints

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -19,8 +19,13 @@ from app.main import bp
 from app.main.forms import CookiesForm
 
 
+@bp.get("/main")
+def index():
+    return redirect(url_for("categories.index"))
+
+
 @bp.get("/start")
-def landing_page():
+def start():
     """This is the main entry point for the service from www.gov.uk/check-legal-aid
     The Welsh version of this page directs the user to /start?locale=cy_GB, we need to set their locale cookie accordingly
     """
@@ -34,7 +39,7 @@ def landing_page():
 
 
 @bp.get("/bsl-start")
-def contact_us():
+def bsl_start():
     """This an entry point for the service from www.gov.uk/check-legal-aid
     This is a route for users who need to contact us via BSL, they are routed directly to the contact us page
     """

--- a/tests/functional_tests/test_entry_points.py
+++ b/tests/functional_tests/test_entry_points.py
@@ -1,0 +1,39 @@
+from playwright.sync_api import Page, expect
+import pytest
+from flask import url_for
+
+
+@pytest.mark.usefixtures("live_server")
+def test_start_route(page: Page):
+    url = url_for("main.start", _external=True)
+    assert url.endswith("/start"), url
+    page.goto(url)
+    expect(
+        page.get_by_role("heading", name="Find problems covered by legal aid")
+    ).to_be_visible()
+
+
+@pytest.mark.usefixtures("live_server")
+def test_start_route_welsh(page: Page):
+    url = url_for("main.start", locale="cy_GB", _external=True)
+    assert url.endswith("/start?locale=cy_GB"), url
+    page.goto(url)
+    locale = page.locator("html").get_attribute("lang")
+    assert locale == "cy", f"Expected 'cy' but got {locale}"
+
+
+@pytest.mark.usefixtures("live_server")
+def test_bsl_route(page: Page):
+    url = url_for("main.bsl_start", _external=True)
+    assert url.endswith("/bsl-start"), url
+    page.goto(url)
+    expect(page.get_by_role("heading", name="Contact us")).to_be_visible()
+
+
+@pytest.mark.usefixtures("live_server")
+def test_bsl_route_welsh(page: Page):
+    url = url_for("main.bsl_start", locale="cy_GB", _external=True)
+    assert url.endswith("/bsl-start?locale=cy_GB"), url
+    page.goto(url)
+    locale = page.locator("html").get_attribute("lang")
+    assert locale == "cy", f"Expected 'cy' but got {locale}"

--- a/tests/unit_tests/test_entry_points.py
+++ b/tests/unit_tests/test_entry_points.py
@@ -1,0 +1,73 @@
+from flask import url_for
+
+
+class TestStartRoute:
+    def test_start_clears_session(self, app, client):
+        with client.session_transaction() as session:
+            session["test_key"] = "test_value"
+
+        client.get("/start")
+
+        with client.session_transaction() as session:
+            assert "test_key" not in session
+
+    def test_start_redirects_to_categories_index(self, client):
+        response = client.get("/start")
+        assert response.status_code == 302
+        assert response.location == url_for("categories.index")
+
+    def test_start_sets_locale_cookie_when_provided(self, client):
+        response = client.get("/start?locale=cy_GB")
+
+        assert response.status_code == 302
+        assert response.location == url_for("categories.index")
+
+        cookies = response.headers.getlist("Set-Cookie")
+        assert any("locale=cy" in cookie for cookie in cookies)
+
+    def test_start_no_locale_cookie_when_not_provided(self, client):
+        response = client.get("/start")
+
+        assert response.status_code == 302
+
+        # Verify no locale cookie is set
+        cookies = response.headers.getlist("Set-Cookie")
+        assert not any("locale=" in cookie for cookie in cookies)
+
+    def test_start_with_invalid_locale(self, client):
+        response = client.get("/start?locale=invalid")
+        assert response.status_code == 404
+
+
+class TestBSLStartRoute:
+    def test_bsl_start_clears_session(self, app, client):
+        with client.session_transaction() as session:
+            session["test_key"] = "test_value"
+
+        client.get("/bsl-start")
+
+        with client.session_transaction() as session:
+            assert "test_key" not in session
+
+    def test_bsl_start_redirects_to_contact_us(self, client):
+        response = client.get("/bsl-start")
+        assert response.status_code == 302
+        assert response.location == url_for("contact.contact_us")
+
+    def test_bsl_start_sets_locale_cookie_when_provided(self, client):
+        response = client.get("/bsl-start?locale=cy_GB")
+
+        # Verify cookie is set
+        cookies = response.headers.getlist("Set-Cookie")
+        assert any("locale=cy" in cookie for cookie in cookies)
+
+    def test_bsl_start_no_locale_cookie_when_not_provided(self, client):
+        response = client.get("/bsl-start")
+
+        # Verify no locale cookie is set
+        cookies = response.headers.getlist("Set-Cookie")
+        assert not any("locale=" in cookie for cookie in cookies)
+
+    def test_bsl_start_with_invalid_locale(self, client):
+        response = client.get("/bsl-start?locale=invalid")
+        assert response.status_code == 404

--- a/tests/unit_tests/test_locale.py
+++ b/tests/unit_tests/test_locale.py
@@ -1,0 +1,50 @@
+import pytest
+from flask import Response
+from werkzeug.exceptions import NotFound
+from app.main.routes import set_locale_cookie
+import datetime as dt
+
+
+@pytest.fixture
+def mock_response():
+    return Response()
+
+
+def test_valid_locale(app, mock_response):
+    response = set_locale_cookie(mock_response, "en")
+
+    cookie = response.headers.get("Set-Cookie")
+
+    expiry_time = dt.datetime.now() + dt.timedelta(days=30)
+
+    assert "locale=en" in cookie
+    assert "Secure" in cookie
+    assert "HttpOnly" in cookie
+    assert "SameSite=Strict" in cookie
+    assert "Expires" in cookie
+    assert expiry_time.strftime("%a, %d %b %Y %H:%M:%S GMT") in cookie
+
+
+def test_locale_with_gb_suffix(app, mock_response):
+    response = set_locale_cookie(mock_response, "en_GB")
+    assert "locale=en" in response.headers.get("Set-Cookie")
+
+
+def test_invalid_locale(app, mock_response):
+    with pytest.raises(NotFound):
+        set_locale_cookie(mock_response, "invalid")
+
+
+def test_none_locale(app, mock_response):
+    response = set_locale_cookie(mock_response, None)
+    assert response.headers.get("Set-Cookie") is None
+
+
+def test_empty_string_locale(app, mock_response):
+    response = set_locale_cookie(mock_response, "")
+    assert response.headers.get("Set-Cookie") is None
+
+
+def test_non_string_locale(app, mock_response):
+    response = set_locale_cookie(mock_response, 123)
+    assert response.headers.get("Set-Cookie") is None


### PR DESCRIPTION
## What does this pull request do?

- Adds the `/start` and `/bsl-start` routes, which are the entry points into the service from [https://www.gov.uk/check-legal-aid](https://www.gov.uk/check-legal-aid)
- These routes support the optional `?local=cy_GB` query string, which sets the users language when included.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
