### PR TITLE
LGA-3529: Add spacing to appeal list

### DIFF
--- a/app/templates/categories/benefits/appeal.html
+++ b/app/templates/categories/benefits/appeal.html
@@ -22,7 +22,7 @@
     <div class="govuk-grid-column-two-thirds">
 
         <h1 class="govuk-heading-xl">{% trans %}Appeal a decision about your benefits{% endtrans %}</h1>
-        <p class="govuk-body govuk-!-margin-bottom-0">{% trans %}Legal aid only covers appeals to the:{% endtrans %}</p>
+        <p class="govuk-body">{% trans %}Legal aid only covers appeals to the:{% endtrans %}</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>{% trans %}Upper Tribunal (Administrative Appeals Chamber){% endtrans %}</li>
             <li>{% trans %}Supreme Court{% endtrans %}</li>


### PR DESCRIPTION
## What does this pull request do?

- Removes 0 margin spacing between main text and the list
<img width="1023" alt="Screenshot 2025-02-17 at 22 32 39" src="https://github.com/user-attachments/assets/2765d87c-8f9c-41c0-9f44-c2040a322f9b" />

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
