### PR TITLE
Update SonarCloud action to use new SonarQube action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           args: format --check
 
-  sonarcloud:
-    name: Sonar cloud
+  sonarqube-scan:
+    name: SonarQube
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,8 +60,8 @@ jobs:
         with:
           name: coverage-xml-report
           path: coverage
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@master
         with:
           args: >
             -Dsonar.python.version=3.12

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           args: format --check
 
-  sonarqube-scan:
+  sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What does this pull request do?

- Updates the Sonar Cloud action to use the new SonarQube action.
- - The Sonar Cloud action is depreciated, please see: [https://github.com/SonarSource/sonarcloud-github-action](https://github.com/SonarSource/sonarcloud-github-action)

The SonarQube action is a drop-in replacement for the action.

Without this change our pipelines are subject to brownouts and will eventually stop working, please see [here](https://github.com/ministryofjustice/laa-access-civil-legal-aid/actions/runs/13400558033/job/37430326619) for an example of a failed job due to a brownout.


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
