### PR TITLE
Make rate limiter optional

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,7 +105,10 @@ def create_app(config_class=Config):
     # Initialise app extensions
     compress.init_app(app)
     csrf.init_app(app)
-    limiter.init_app(app)
+
+    if app.config["RATELIMIT_ENABLED"]:
+        limiter.init_app(app)
+
     talisman.init_app(
         app,
         content_security_policy=csp if not Config.TESTING else None,

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -13,7 +13,8 @@ class Config(object):
     DEPARTMENT_NAME = os.environ.get("DEPARTMENT_NAME", "MOJ Digital")
     DEPARTMENT_URL = os.environ.get("DEPARTMENT_URL", "https://mojdigital.blog.gov.uk/")
     TESTING = False
-    RATELIMIT_HEADERS_ENABLED = True
+    RATELIMIT_ENABLED = os.environ.get("RATELIMIT_ENABLED", "True").lower() == "true"
+    RATELIMIT_HEADERS_ENABLED = RATELIMIT_ENABLED
     RATELIMIT_STORAGE_URI = os.environ.get("REDIS_URL")
     SECRET_KEY = os.environ["SECRET_KEY"]
     SERVICE_NAME = "Access Civil Legal Aid"

--- a/helm_deploy/laa-access-civil-legal-aid/values.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values.yaml
@@ -73,3 +73,8 @@ envVars:
       name: maintenance-mode
       key: enabled
       optional: true
+  RATELIMIT_ENABLED:
+    configmap:
+      name: ratelimit
+      key: enabled
+      optional: true


### PR DESCRIPTION
## What does this pull request do?

- Makes the rate limiter dependent on the `RATELIMIT_ENABLED` envvar, which can be set via a configmap.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
