### PR TITLE
Header redirect to GOV.UK

### DIFF
--- a/app/categories/urls.py
+++ b/app/categories/urls.py
@@ -1,4 +1,4 @@
-from flask import session, url_for, render_template
+from flask import url_for, render_template
 from app.categories import bp
 from app.categories.views import CategoryPage
 from app.categories.constants import (
@@ -31,12 +31,12 @@ class IndexPage(CategoryPage):
             (ASYLUM_AND_IMMIGRATION, url_for("categories.asylum_immigration.landing")),
             (MENTAL_CAPACITY, url_for("categories.mental_capacity.landing")),
         ]
-        session.clear()
         return render_template(self.template, listing=listing)
 
 
 bp.add_url_rule(
-    "/", view_func=IndexPage.as_view("index", template="categories/index.html")
+    "/find-your-problem",
+    view_func=IndexPage.as_view("index", template="categories/index.html"),
 )
 bp.add_url_rule(
     "/more-problems",

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -8,6 +8,9 @@ load_dotenv()
 
 class Config(object):
     ENVIRONMENT = os.environ.get("CLA_ENVIRONMENT", "production")
+    GOV_UK_START_PAGE = os.environ.get(
+        "GOV_UK_START_PAGE", "https://www.gov.uk/check-legal-aid"
+    )
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "")
     DEPARTMENT_NAME = os.environ.get("DEPARTMENT_NAME", "MOJ Digital")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -102,7 +102,7 @@ def status():
 @bp.route("/service-unavailable", methods=["GET"])
 def service_unavailable_page():
     if not current_app.config["SERVICE_UNAVAILABLE"]:
-        return redirect(url_for("main.index"))
+        return redirect(url_for("categories.index"))
     abort(503)
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -19,9 +19,15 @@ from app.main import bp
 from app.main.forms import CookiesForm
 
 
-@bp.get("/main")
-def index():
-    return redirect(url_for("categories.index"))
+@bp.get("/")
+def start_page():
+    """Directs the user to the start page of the service, hosted on GOV.UK
+    This is the endpoint directed to from the header text, clicking this link will reset the users' session.
+    """
+    session.clear()
+    if current_app.config.get("CLA_ENVIRONMENT") != "production":
+        return redirect(url_for("categories.index"))
+    return redirect(current_app.config.get("GOV_UK_START_PAGE"))
 
 
 @bp.get("/start")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -115,10 +115,10 @@
 
 {% block header %}
     {{ govukHeader({
-    'homepageUrl': url_for('categories.index'),
-    'serviceName': config['SERVICE_NAME'],
-    'serviceUrl': url_for('categories.index'),
-    'useTudorCrown': true
+        'homepageUrl': "https://gov.uk",
+        'serviceName': config['SERVICE_NAME'],
+        'serviceUrl': url_for('main.start_page'),
+        'useTudorCrown': true
   }) }}
 {% endblock %}
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -115,7 +115,7 @@
 
 {% block header %}
     {{ govukHeader({
-        'homepageUrl': "https://gov.uk",
+        'homepageUrl': "https://www.gov.uk",
         'serviceName': config['SERVICE_NAME'],
         'serviceUrl': url_for('main.start_page'),
         'useTudorCrown': true

--- a/app/templates/main/session_expired.html
+++ b/app/templates/main/session_expired.html
@@ -13,7 +13,7 @@
         <p class="govuk-body">{% trans %}You can start again below.{% endtrans %}</p>
         {{ govukButton({
             "text": _("Start again"),
-            "href": url_for("main.index"),
+            "href": url_for("main.start_page"),
             "isStartButton": true
         }) }}
     </div>

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -40,4 +40,4 @@ def runner(app):
 
 @pytest.fixture(scope="function", autouse=True)
 def startup(app, page):
-    page.goto(url_for("main.index", _external=True))
+    page.goto(url_for("categories.index", _external=True))

--- a/tests/functional_tests/test_header.py
+++ b/tests/functional_tests/test_header.py
@@ -1,0 +1,16 @@
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.usefixtures("live_server")
+def test_service_url(page: Page):
+    expect(page.get_by_role("link", name="Access Civil Legal Aid")).to_have_attribute(
+        "href", value="/"
+    )
+
+
+@pytest.mark.usefixtures("live_server")
+def test_gov_uk_url(page: Page):
+    expect(page.get_by_role("link", name="GOV.UK")).to_have_attribute(
+        "href", "https://www.gov.uk"
+    )

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -4,7 +4,7 @@ from app.main.filters import category_url_for
 def test_filter_category_url(app):
     with app.app_context():
         # url is a string
-        assert category_url_for("categories.index") == "/"
+        assert category_url_for("categories.index") == "/find-your-problem"
         endpoint = {
             "endpoint": "find-a-legal-adviser.search",
             "category": "mhe",

--- a/tests/unit_tests/test_pages.py
+++ b/tests/unit_tests/test_pages.py
@@ -25,4 +25,14 @@ def test_service_unavailable_off(app, client):
     app.config["SERVICE_UNAVAILABLE"] = False
     response = client.get("/service-unavailable", follow_redirects=True)
     assert response.status_code == 200
-    assert response.request.path == "/"
+    assert response.request.path == "/find-your-problem"
+
+
+def test_header_link_clears_session(app, client):
+    with client.session_transaction() as session:
+        session["test"] = "test"
+
+    client.get("/")
+
+    with client.session_transaction() as session:
+        assert "test" not in session


### PR DESCRIPTION
## What does this pull request do?

- The header URL and `"/"` endpoint redirects to the GOV.UK service start page on production, and clears the users session
- The users session is no longer cleared by the category landing page
- The GOV.UK link in the header directs to the GOV.UK homepage
- The category landing page now exists at `/find-your-problem` as intended

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
