### PR TITLE
Fix incorrect URLs

### DIFF
--- a/app/categories/asylum_immigration/urls.py
+++ b/app/categories/asylum_immigration/urls.py
@@ -32,7 +32,7 @@ AsylumAndImmigrationLandingPage.register_routes(
     blueprint=bp, path="/asylum-and-immigration"
 )
 bp.add_url_rule(
-    "/mental-capacity-health/cannot-find-your-problem",
+    "/asylum-and-immigration/cannot-find-your-problem",
     view_func=CannotFindYourProblemPage.as_view(
         "cannot_find_your_problem",
         category=ASYLUM_AND_IMMIGRATION,
@@ -40,7 +40,7 @@ bp.add_url_rule(
     ),
 )
 bp.add_url_rule(
-    "/mental-capacity-health/next-steps",
+    "/asylum-and-immigration/next-steps",
     view_func=NextStepsPage.as_view(
         "next_steps",
         category=ASYLUM_AND_IMMIGRATION,

--- a/app/categories/benefits/urls.py
+++ b/app/categories/benefits/urls.py
@@ -5,7 +5,7 @@ from ..results.views import CannotFindYourProblemPage, NextStepsPage
 from ..views import QuestionPage
 
 bp.add_url_rule(
-    "/benefits/appeal",
+    "/benefits-appeal",
     view_func=QuestionPage.as_view(
         "appeal",
         form_class=AppealQuestionForm,
@@ -13,7 +13,7 @@ bp.add_url_rule(
     ),
 )
 bp.add_url_rule(
-    "/benefits/cannot-find-your-problem",
+    "/benefits-appeal/cannot-find-your-problem",
     view_func=CannotFindYourProblemPage.as_view(
         "cannot_find_your_problem",
         category=BENEFITS,
@@ -21,7 +21,7 @@ bp.add_url_rule(
     ),
 )
 bp.add_url_rule(
-    "/benefits/next-steps",
+    "/benefits-appeal/next-steps",
     view_func=NextStepsPage.as_view(
         "next_steps",
         category=BENEFITS,

--- a/app/categories/community_care/urls.py
+++ b/app/categories/community_care/urls.py
@@ -30,9 +30,9 @@ class CommunityCareLandingPage(CategoryLandingPage):
     }
 
 
-CommunityCareLandingPage.register_routes(blueprint=bp)
+CommunityCareLandingPage.register_routes(blueprint=bp, path="/disability-social-care")
 bp.add_url_rule(
-    "/community-care/cannot-find-your-problem",
+    "/disability-social-care/cannot-find-your-problem",
     view_func=CannotFindYourProblemPage.as_view(
         "cannot_find_your_problem",
         category=COMMUNITY_CARE,
@@ -40,7 +40,7 @@ bp.add_url_rule(
     ),
 )
 bp.add_url_rule(
-    "/community-care/next-steps",
+    "/disability-social-care/next-steps",
     view_func=NextStepsPage.as_view(
         "next_steps",
         category=COMMUNITY_CARE,

--- a/app/categories/family/urls.py
+++ b/app/categories/family/urls.py
@@ -34,14 +34,14 @@ class FamilyLandingPage(CategoryLandingPage):
 
 FamilyLandingPage.register_routes(bp, path="children-families-relationships")
 bp.add_url_rule(
-    "/family/cannot-find-your-problem",
+    "/children-families-relationships/cannot-find-your-problem",
     view_func=CannotFindYourProblemPage.as_view(
         "cannot_find_your_problem",
         next_steps_page="categories.family.next_steps",
     ),
 )
 bp.add_url_rule(
-    "/family/next-steps",
+    "/children-families-relationships/next-steps",
     view_func=NextStepsPage.as_view(
         "next_steps",
         category=FAMILY,

--- a/app/categories/mental_capacity/urls.py
+++ b/app/categories/mental_capacity/urls.py
@@ -34,7 +34,6 @@ class MentalCapacityLandingPage(CategoryLandingPage):
                     "category": "mhe",
                 },
             ),
-            # Todo: # This needs to be updated to route to the community care landing page once it has been made
             (MENTAL_CAPACITY.sub.social_care, "categories.community_care.landing"),
         ],
         "more": [],

--- a/app/categories/public/urls.py
+++ b/app/categories/public/urls.py
@@ -11,21 +11,21 @@ class PublicLandingPage(CategoryLandingPage):
 
 
 bp.add_url_rule(
-    "/public",
+    "/public-organisations",
     view_func=PublicLandingPage.as_view(
         "landing", template="categories/public/landing.html"
     ),
 )
 
 bp.add_url_rule(
-    "/public/reason",
+    "/public-organisations/reason",
     view_func=QuestionPage.as_view(
         "reason",
         form_class=PolicePrisonOrDetentionCentreForm,
     ),
 )
 bp.add_url_rule(
-    "/public/cannot-find-your-problem",
+    "/public-organisations/cannot-find-your-problem",
     view_func=CannotFindYourProblemPage.as_view(
         "cannot_find_your_problem",
         next_steps_page="categories.public.next_steps",


### PR DESCRIPTION
## What does this pull request do?

- Updates category URLs to match those found in the "Access URLs" record: [https://docs.google.com/spreadsheets/d/1KIxjCa0gmEkke7Lwlk_BEFy8m1KQGKIG-kzKZ602ohw](https://docs.google.com/spreadsheets/d/1KIxjCa0gmEkke7Lwlk_BEFy8m1KQGKIG-kzKZ602ohw)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
