### PR TITLE
Fix: Allow static assets to be served when the service is unavailable

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -177,6 +177,10 @@ def service_unavailable_middleware():
     if not current_app.config["SERVICE_UNAVAILABLE"]:
         return
 
+    # Allow requests for static assets, this is required for the service unavailable page to render correctly
+    if request.path.startswith("/assets/"):
+        return
+
     service_unavailable_url = url_for("main.service_unavailable_page")
     exempt_urls = [
         service_unavailable_url,

--- a/tests/unit_tests/test_pages.py
+++ b/tests/unit_tests/test_pages.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_set_locale(app, client):
     response = client.get("/locale/cy", headers={"referer": "http://localhost/privacy"})
     assert response.status_code == 302
@@ -19,6 +22,17 @@ def test_service_unavailable_on(app, client):
     response = client.get("/", follow_redirects=True)
     assert response.status_code == 503
     assert response.request.path == "/service-unavailable"
+
+
+@pytest.mark.parametrize(
+    "resource_path",
+    ["/assets/styles.css", "/assets/scripts.js", "/assets/images/govuk-crest.png"],
+)
+def test_service_unavailable_static_assets(app, client, resource_path):
+    app.config["SERVICE_UNAVAILABLE"] = True
+    response = client.get(resource_path)
+    assert response.status_code == 200
+    assert response.request.path == resource_path
 
 
 def test_service_unavailable_off(app, client):


### PR DESCRIPTION
## What does this pull request do?

- Allows requests for static assets to go through when the service is unavailable.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
