### PR TITLE
LGA-3479: Disallow search engine indexing

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -5,6 +5,7 @@ bp = Blueprint("main", __name__, template_folder="../templates/main")
 
 from app.main import routes  # noqa: E402,F401
 from app.main import filters  # noqa: E402,F401
+from app.main import middleware  # noqa: E402,F401
 
 
 def get_locale():

--- a/app/main/middleware.py
+++ b/app/main/middleware.py
@@ -1,0 +1,8 @@
+from app.main import bp
+
+
+@bp.after_app_request
+def add_noindex_header(response):
+    """Add a noindex header to all responses, to disallow search engines from indexing the page."""
+    response.headers["X-Robots-Tag"] = "noindex"
+    return response

--- a/tests/unit_tests/test_middleware.py
+++ b/tests/unit_tests/test_middleware.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/",
+        "/children-families-relationships",
+        "/cookies",
+        "/assets/images/favicon.svg",
+        "/assets/scripts.js",
+        "/assets/styles.css",
+        "/404-page",
+        "/service-unavailable",
+    ],
+)
+def test_noindex_header_on_routes(client, endpoint):
+    response = client.get(endpoint)
+    assert response.headers.get("X-Robots-Tag") == "noindex"


### PR DESCRIPTION
## What does this pull request do?

- Disallows search engine indexing by adding `X-Robots-Tag=noindex` to the response headers of all requests.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
