### PR TITLE
Get users' subcategory

### DIFF
--- a/app/categories/constants.py
+++ b/app/categories/constants.py
@@ -509,5 +509,13 @@ ALL_CATEGORIES = {
 list(map(init_children, ALL_CATEGORIES.values()))
 
 
-def get_category_from_code(code: str) -> Category:
+def get_category_from_code(code: str) -> Category | None:
+    if not code:
+        return None
     return ALL_CATEGORIES[code]
+
+
+def get_subcategory_from_code(parent_code: str, code: str) -> Category | None:
+    if not parent_code or not code:
+        return None
+    return get_category_from_code(parent_code).children[code]

--- a/app/categories/discrimination/urls.py
+++ b/app/categories/discrimination/urls.py
@@ -1,3 +1,4 @@
+from flask import redirect, url_for
 from . import bp
 from .forms import (
     DiscriminationWhereForm,
@@ -6,8 +7,25 @@ from .forms import (
 )
 from ..constants import DISCRIMINATION
 from ..results.views import CannotFindYourProblemPage, NextStepsPage
-from ..views import QuestionPage
+from ..views import QuestionPage, CategoryLandingPage
 
+
+class DiscriminationCategoryLandingPage(CategoryLandingPage):
+    category = DISCRIMINATION
+
+    def __init__(self):
+        super().__init__(
+            template=None,
+        )
+
+    def dispatch_request(self):
+        super().set_category_answer()
+        return redirect(url_for("categories.discrimination.where"))
+
+
+bp.add_url_rule(
+    "/discrimination/", view_func=DiscriminationCategoryLandingPage.as_view("landing")
+)
 bp.add_url_rule(
     "/discrimination/where",
     view_func=QuestionPage.as_view("where", form_class=DiscriminationWhereForm),

--- a/app/categories/discrimination/urls.py
+++ b/app/categories/discrimination/urls.py
@@ -19,7 +19,7 @@ class DiscriminationCategoryLandingPage(CategoryLandingPage):
         )
 
     def dispatch_request(self):
-        super().set_category_answer()
+        self.set_category_answer()
         return redirect(url_for("categories.discrimination.where"))
 
 

--- a/app/categories/models.py
+++ b/app/categories/models.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Optional
 
 from flask import url_for
-from flask_babel import LazyString
 
 from app.categories.constants import Category
 
@@ -18,7 +17,7 @@ class QuestionType(str, Enum):
 class CategoryAnswer:
     question: str
     answer_value: str
-    answer_label: str | LazyString
+    answer_label: str
     category: Category
     question_page: str
     next_page: str

--- a/app/categories/models.py
+++ b/app/categories/models.py
@@ -7,6 +7,7 @@ from app.categories.constants import Category
 
 
 class QuestionType(str, Enum):
+    CATEGORY = "category"
     SUB_CATEGORY = "sub_category"
     ONWARD = "onward_question"
 

--- a/app/categories/models.py
+++ b/app/categories/models.py
@@ -3,6 +3,8 @@ from enum import Enum
 from typing import Optional
 
 from flask import url_for
+from flask_babel import LazyString
+
 from app.categories.constants import Category
 
 
@@ -16,7 +18,7 @@ class QuestionType(str, Enum):
 class CategoryAnswer:
     question: str
     answer_value: str
-    answer_label: str
+    answer_label: str | LazyString
     category: Category
     question_page: str
     next_page: str

--- a/app/categories/urls.py
+++ b/app/categories/urls.py
@@ -1,4 +1,4 @@
-from flask import url_for, render_template
+from flask import url_for, render_template, session
 from app.categories import bp
 from app.categories.views import CategoryPage
 from app.categories.constants import (
@@ -23,7 +23,7 @@ class IndexPage(CategoryPage):
             (FAMILY, url_for("categories.family.landing")),
             (HOUSING, url_for("categories.housing.landing")),
             (DOMESTIC_ABUSE, url_for("categories.domestic_abuse.landing")),
-            (DISCRIMINATION, url_for("categories.discrimination.where")),
+            (DISCRIMINATION, url_for("categories.discrimination.landing")),
             (EDUCATION, url_for("categories.send.landing")),
             (COMMUNITY_CARE, url_for("categories.community_care.landing")),
             (BENEFITS, url_for("categories.benefits.appeal")),
@@ -44,3 +44,8 @@ bp.add_url_rule(
         "more_problems", template="categories/more-problems.html"
     ),
 )
+
+
+@bp.get("/session")
+def session_route():
+    return dict(session)

--- a/app/categories/urls.py
+++ b/app/categories/urls.py
@@ -1,4 +1,4 @@
-from flask import url_for, render_template, session
+from flask import url_for, render_template
 from app.categories import bp
 from app.categories.views import CategoryPage
 from app.categories.constants import (
@@ -44,8 +44,3 @@ bp.add_url_rule(
         "more_problems", template="categories/more-problems.html"
     ),
 )
-
-
-@bp.get("/session")
-def session_route():
-    return dict(session)

--- a/app/categories/views.py
+++ b/app/categories/views.py
@@ -22,10 +22,6 @@ class CategoryPage(View):
         session.set_category_question_answer(category_answer)
 
     def dispatch_request(self):
-        category = getattr(self, "category", None)
-        if category is not None:
-            session.category = category
-
         response = self.process_request()
         if not response:
             response = render_template(self.template)
@@ -52,6 +48,7 @@ class CategoryLandingPage(CategoryPage):
 
     def __init__(self, route_endpoint: str = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.route_endpoint = route_endpoint
         if self.routing_map and route_endpoint:
             self.listing["main"] = []
             for category, next_page in self.routing_map["main"]:
@@ -68,6 +65,17 @@ class CategoryLandingPage(CategoryPage):
             self.listing["other"] = f"categories.{route_endpoint}.other"
 
     def process_request(self):
+        self.update_session(
+            CategoryAnswer(
+                question="Choose the problem you need help with.",
+                question_page="categories.index",
+                answer_value=self.category.code,
+                answer_label=self.category.title,
+                category=self.category,
+                question_type=QuestionType.CATEGORY,
+                next_page=f"categories.{self.route_endpoint}.landing",
+            )
+        )
         return render_template(
             self.template, category=self.category, listing=self.listing
         )

--- a/app/categories/views.py
+++ b/app/categories/views.py
@@ -64,7 +64,7 @@ class CategoryLandingPage(CategoryPage):
 
             self.listing["other"] = f"categories.{route_endpoint}.other"
 
-    def process_request(self):
+    def set_category_answer(self) -> None:
         self.update_session(
             CategoryAnswer(
                 question="Choose the problem you need help with.",
@@ -76,6 +76,9 @@ class CategoryLandingPage(CategoryPage):
                 next_page=f"categories.{self.route_endpoint}.landing",
             )
         )
+
+    def process_request(self):
+        self.set_category_answer()
         return render_template(
             self.template, category=self.category, listing=self.listing
         )

--- a/app/means_test/views.py
+++ b/app/means_test/views.py
@@ -46,7 +46,11 @@ class MeansTest(FormsMixin, View):
         elif "remove-property-2" in request.form or "remove-property-3" in request.form:
             form.properties.pop_entry()
             form._submitted = False
-            return render_template(self.form_class.template, form=form)
+            return render_template(
+                self.form_class.template,
+                form=form,
+                form_progress=self.get_form_progress(current_form=form),
+            )
 
         return None
 

--- a/tests/functional_tests/means_test/test_review.py
+++ b/tests/functional_tests/means_test/test_review.py
@@ -132,7 +132,8 @@ def test_reviews_page_change_benefits_answer(page: Page, complete_benefits_form)
 def test_reviews_page_change_sub_category(page: Page, complete_benefits_form):
     answers = get_answers()
     expect(page).to_have_title("Check your answers and confirm - GOV.UK")
-    page.locator(".govuk-summary-list__actions a[href='/housing/']").click()
+    page.locator(".govuk-summary-list__actions a[href='/find-your-problem']").click()
+    page.get_by_text("Housing, homelessness, losing your home").click()
     page.get_by_text("Eviction, told to leave your home").click()
     expect(page).to_have_title(
         "Legal aid is available for this type of problem - Access Civil Legal Aid – GOV.UK"

--- a/tests/unit_tests/categories/test_session.py
+++ b/tests/unit_tests/categories/test_session.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import url_for
 
 from app.categories.constants import Category, HOUSING
 from app.categories.models import CategoryAnswer, QuestionType
@@ -101,6 +102,27 @@ def test_set_category_dataclass(app, client):
         session["category"] = {"code": EDUCATION.code}
         assert session.category == EDUCATION
         assert isinstance(session.category, Category)
+
+
+class TestPrimaryCategoryAnswer:
+    @pytest.mark.parametrize(
+        "category",
+        [
+            "housing",
+            "discrimination",
+            "family",
+            "send",
+        ],
+    )
+    def test_set_category(self, category, app, client):
+        client.get(url_for(f"categories.{category}.landing"))
+
+        with client.session_transaction() as session:
+            assert len(session.category_answers) == 1
+            category_answer = session.category_answers[0]
+            assert category_answer.question == "Choose the problem you need help with."
+            assert category_answer.answer_value == category
+            assert isinstance(category_answer, CategoryAnswer)
 
 
 class TestSessionSubcategory:

--- a/tests/unit_tests/means_test/test_views_summary.py
+++ b/tests/unit_tests/means_test/test_views_summary.py
@@ -3,7 +3,7 @@ from flask_babel import lazy_gettext as _
 from app.means_test.views import CheckYourAnswers, ReviewForm
 from app.means_test import YES, NO
 from app.session import Eligibility
-from app.categories.models import CategoryAnswer
+from app.categories.models import CategoryAnswer, QuestionType
 from app.categories.constants import DISCRIMINATION, HOUSING
 
 
@@ -142,6 +142,7 @@ def test_get_category_answers_summary_no_description(app):
             answer_value="work",
             next_page="categories.discrimination.why",
             question_page="categories.discrimination.where",
+            question_type=QuestionType.ONWARD,
         ),
         CategoryAnswer(
             question="Why were you discriminated against?",
@@ -150,6 +151,7 @@ def test_get_category_answers_summary_no_description(app):
             answer_value="disability",
             next_page="categories.discrimination.age",
             question_page="categories.discrimination.why",
+            question_type=QuestionType.ONWARD,
         ),
         CategoryAnswer(
             question="Are you under 18?",
@@ -158,6 +160,7 @@ def test_get_category_answers_summary_no_description(app):
             answer_value="no",
             next_page="categories.index",
             question_page="categories.discrimination.age",
+            question_type=QuestionType.ONWARD,
         ),
     ]
 
@@ -179,7 +182,7 @@ def test_get_category_answers_summary_with_description(app):
             "value": {
                 "markdown": "**Homelessness**\nHelp if you’re homeless, or might be homeless in the next 2 months. This could be because of rent arrears, debt, the end of a relationship, or because you have nowhere to live."
             },
-            "actions": {"items": [{"text": _("Change"), "href": "/housing/"}]},
+            "actions": {"items": [{"text": _("Change"), "href": "/find-your-problem"}]},
         },
         {
             "key": {"text": "Are you under 18?"},
@@ -198,6 +201,7 @@ def test_get_category_answers_summary_with_description(app):
             answer_value="homelessness",
             next_page="categories.discrimination.age",
             question_page="categories.housing.landing",
+            question_type=QuestionType.SUB_CATEGORY,
         ),
         CategoryAnswer(
             question="Are you under 18?",
@@ -206,6 +210,7 @@ def test_get_category_answers_summary_with_description(app):
             answer_value="no",
             next_page="categories.index",
             question_page="categories.discrimination.age",
+            question_type=QuestionType.ONWARD,
         ),
     ]
 


### PR DESCRIPTION
## What does this pull request do?

- Adds functionality to get the users subcategory from the session
- Stores the users answer to the initial category question to the `CategoryAnswers` list as a new `CATEGORY` question type.
- Updates the 'Check your answers' page to use this new information rather than relying on the order of the Category Answers.


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
