### PR TITLE
Refactor means test to use boolean for Radio Field values

### DIFF
--- a/app/means_test/__init__.py
+++ b/app/means_test/__init__.py
@@ -1,16 +1,5 @@
 from flask import Blueprint
-from flask_babel import lazy_gettext as _
 
 bp = Blueprint("means_test", __name__)
-
-YES = "1"
-YES_LABEL = _("Yes")
-NO = "0"
-NO_LABEL = _("No")
-
-
-def is_yes(value):
-    return YES == value
-
 
 from app.means_test import urls  # noqa: E402,F401

--- a/app/means_test/api.py
+++ b/app/means_test/api.py
@@ -203,4 +203,7 @@ def get_means_test_payload(eligibility_data) -> dict:
     if not has_partner:
         del payload["partner"]
 
+    import json
+
+    print(json.dumps(payload))
     return payload

--- a/app/means_test/fields.py
+++ b/app/means_test/fields.py
@@ -2,13 +2,42 @@ import decimal
 from decimal import Decimal, InvalidOperation
 
 from flask import render_template
-from flask_babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _, LazyString
 from wtforms.widgets import TextInput
 from markupsafe import Markup
-from wtforms import Field, IntegerField as BaseIntegerField
+from wtforms import Field, IntegerField as BaseIntegerField, RadioField
 from app.means_test.money_interval import MoneyInterval
 import re
 from app.means_test.validators import CurrencyValidator
+
+
+class YesNoField(RadioField):
+    def __init__(self, label: LazyString = None, validators=None, **kwargs):
+        if "coerce" in kwargs:
+            raise ValueError("The 'coerce' parameter is not allowed in a YesNoField")
+        if "choices" in kwargs:
+            raise ValueError(
+                "Choices in a YesNoField are fixed and cannot be overridden"
+            )
+        choices = [(True, _("Yes")), (False, _("No"))]
+        coerce = self._coerce_to_boolean
+        super(YesNoField, self).__init__(
+            label=label, validators=validators, choices=choices, coerce=coerce, **kwargs
+        )  # noqa
+
+    @staticmethod
+    def _coerce_to_boolean(value):
+        # Converts the string value from the HTML request to a boolean
+        # "Yes" being True, "No" being False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("true", "yes", "y", "1", "t")
+        return bool(value)
+
+    @property
+    def value(self):
+        return _("Yes") if self.data else _("No")
 
 
 class MoneyIntervalWidget(TextInput):

--- a/app/means_test/forms/__init__.py
+++ b/app/means_test/forms/__init__.py
@@ -5,7 +5,12 @@ from wtforms.fields.choices import SelectField, SelectMultipleField
 from wtforms.csrf.core import CSRFTokenField
 from flask_babel import lazy_gettext as _
 from flask import session
-from app.means_test.fields import MoneyIntervalField, MoneyInterval, MoneyField
+from app.means_test.fields import (
+    MoneyIntervalField,
+    MoneyInterval,
+    MoneyField,
+    YesNoField,
+)
 import decimal
 from wtforms.fields.core import Field
 from app.means_test.validators import ValidateIf, StopValidation, ValidateIfSession
@@ -100,7 +105,9 @@ class BaseMeansTestForm(FlaskForm):
             question = str(field_instance.label.text)
             answer = field_instance.data
 
-            if isinstance(field_instance, SelectField):
+            if isinstance(field_instance, YesNoField):
+                answer = field_instance.value
+            elif isinstance(field_instance, SelectField):
                 answer = self.get_selected_answer(field_instance)
             elif isinstance(field_instance, MoneyIntervalField):
                 answer = self.get_money_interval_field_answers(field_instance)

--- a/app/means_test/forms/about_you.py
+++ b/app/means_test/forms/about_you.py
@@ -1,12 +1,10 @@
-from wtforms.fields import RadioField
 from govuk_frontend_wtf.wtforms_widgets import GovTextInput
 from wtforms.validators import InputRequired, NumberRange
 from app.means_test.validators import ValidateIf
 from app.means_test.widgets import MeansTestRadioInput
 from flask_babel import lazy_gettext as _
-from app.means_test import YES, NO
 from app.means_test.forms import BaseMeansTestForm
-from app.means_test.fields import IntegerField
+from app.means_test.fields import IntegerField, YesNoField
 
 
 class AboutYouForm(BaseMeansTestForm):
@@ -14,9 +12,8 @@ class AboutYouForm(BaseMeansTestForm):
 
     template = "means_test/about-you.html"
 
-    has_partner = RadioField(
+    has_partner = YesNoField(
         _("Do you have a partner?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_(
             "Your husband, wife, civil partner (unless you have permanently separated) or someone you live with as if you're married"
@@ -24,32 +21,29 @@ class AboutYouForm(BaseMeansTestForm):
         validators=[InputRequired(message=_("Tell us whether you have a partner"))],
     )
 
-    are_you_in_a_dispute = RadioField(
+    are_you_in_a_dispute = YesNoField(
         _("Are you in a dispute with your partner?"),
         description=_(
             "This means your partner is the opponent in the dispute you need help with, for example a dispute over money or property"
         ),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         validators=[
-            ValidateIf("has_partner", YES),
+            ValidateIf("has_partner", True),
             InputRequired(
                 message=_("Tell us whether you're in dispute with your partner")
             ),
         ],
     )
 
-    on_benefits = RadioField(
+    on_benefits = YesNoField(
         _("Do you receive any benefits (including Child Benefit)?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_("Being on some benefits can help you qualify for legal aid"),
         validators=[InputRequired(message=_("Tell us whether you receive benefits"))],
     )
 
-    have_children = RadioField(
+    have_children = YesNoField(
         _("Do you have any children aged 15 or under?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_("Don't include any children who don't live with you"),
         validators=[
@@ -63,7 +57,7 @@ class AboutYouForm(BaseMeansTestForm):
         _("How many?"),
         widget=GovTextInput(),
         validators=[
-            ValidateIf("have_children", YES),
+            ValidateIf("have_children", True),
             InputRequired(
                 message=_("Tell us how many children you have aged 15 or under")
             ),
@@ -71,9 +65,8 @@ class AboutYouForm(BaseMeansTestForm):
         ],
     )
 
-    have_dependents = RadioField(
+    have_dependents = YesNoField(
         _("Do you have any dependants aged 16 or over?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_(
             "People who you live with and support financially. This could be a young person for whom you get Child Benefit"
@@ -89,23 +82,21 @@ class AboutYouForm(BaseMeansTestForm):
         _("How many?"),
         widget=GovTextInput(),
         validators=[
-            ValidateIf("have_dependents", YES),
+            ValidateIf("have_dependents", True),
             InputRequired(_("Tell us how many dependants you have aged 16 or over")),
             NumberRange(min=1, max=50, message=_("Enter a number between 1 and 50")),
         ],
     )
 
-    own_property = RadioField(
+    own_property = YesNoField(
         _("Do you own any property?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_("For example, a house, static caravan or flat"),
         validators=[InputRequired(message=_("Tell us if you own any properties"))],
     )
 
-    is_employed = RadioField(
+    is_employed = YesNoField(
         _("Are you employed?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_(
             "This means working as an employee - you may be both employed and self-employed"
@@ -113,22 +104,20 @@ class AboutYouForm(BaseMeansTestForm):
         validators=[InputRequired(message=_("Tell us if you are employed"))],
     )
 
-    partner_is_employed = RadioField(
+    partner_is_employed = YesNoField(
         _("Is your partner employed?"),
         description=_(
             "This means working as an employee - your partner may be both employed and self-employed"
         ),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         validators=[
-            ValidateIf("are_you_in_a_dispute", NO),
+            ValidateIf("are_you_in_a_dispute", False),
             InputRequired(message=_("Tell us whether your partner is employed")),
         ],
         widget=MeansTestRadioInput(),
     )
 
-    is_self_employed = RadioField(
+    is_self_employed = YesNoField(
         _("Are you self-employed?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         description=_(
             "This means working for yourself - you may be both employed and self-employed"
@@ -136,22 +125,20 @@ class AboutYouForm(BaseMeansTestForm):
         validators=[InputRequired(message=_("Tell us if you are self-employed"))],
     )
 
-    partner_is_self_employed = RadioField(
+    partner_is_self_employed = YesNoField(
         _("Is your partner self-employed?"),
         description=_(
             "This means working for yourself - your partner may be both employed and self-employed"
         ),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         validators=[
-            ValidateIf("are_you_in_a_dispute", NO),
+            ValidateIf("are_you_in_a_dispute", False),
             InputRequired(message=_("Tell us whether your partner is self-employed")),
         ],
         widget=MeansTestRadioInput(),
     )
 
-    aged_60_or_over = RadioField(
+    aged_60_or_over = YesNoField(
         _("Are you or your partner (if you have one) aged 60 or over?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         validators=[
             InputRequired(
@@ -160,18 +147,16 @@ class AboutYouForm(BaseMeansTestForm):
         ],
     )
 
-    have_savings = RadioField(
+    have_savings = YesNoField(
         _("Do you have any savings or investments?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         validators=[
             InputRequired(message=_("Tell us whether you have savings or investments"))
         ],
     )
 
-    have_valuables = RadioField(
+    have_valuables = YesNoField(
         _("Do you have any valuable items worth over £500 each?"),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         widget=MeansTestRadioInput(),
         validators=[
             InputRequired(

--- a/app/means_test/forms/benefits.py
+++ b/app/means_test/forms/benefits.py
@@ -11,7 +11,6 @@ from app.means_test.validators import (
     ValidateIf,
     ValidateIfType,
 )
-from app.means_test import YES, NO
 from dataclasses import dataclass, field
 
 
@@ -193,7 +192,6 @@ class AdditionalBenefitsForm(BaseMeansTestForm):
             "Allowance"
         ),
         widget=MeansTestRadioInput(),
-        choices=[(YES, _("Yes")), (NO, _("No"))],
         validators=[
             InputRequired(message=_("Tell us whether you receive any other benefits"))
         ],
@@ -204,7 +202,7 @@ class AdditionalBenefitsForm(BaseMeansTestForm):
         exclude_intervals=["per_month"],
         widget=MoneyIntervalWidget(),
         validators=[
-            ValidateIf("other_benefits", YES),
+            ValidateIf("other_benefits", True),
             MoneyIntervalAmountRequired(
                 message=_("Tell us how much you receive in other benefits"),
                 freq_message=_("Tell us how often you receive these other benefits"),

--- a/app/means_test/partner_fields.py
+++ b/app/means_test/partner_fields.py
@@ -1,5 +1,6 @@
 from flask import session
-from wtforms.fields import SelectMultipleField, RadioField
+from wtforms.fields import SelectMultipleField
+from app.means_test.fields import YesNoField
 
 
 class PartnerMixin(object):
@@ -18,5 +19,5 @@ class PartnerMultiCheckboxField(PartnerMixin, SelectMultipleField):
     pass
 
 
-class PartnerYesNoField(PartnerMixin, RadioField):
+class PartnerYesNoField(PartnerMixin, YesNoField):
     pass

--- a/app/session.py
+++ b/app/session.py
@@ -22,69 +22,57 @@ class Eligibility:
     def category(self):
         return session.get("category", {}).get("chs_code")
 
-    def is_yes(self, form_name, field_name) -> bool | None:
-        form = self.forms.get(form_name)
-        if not form:
-            return False
-        return form.get(field_name) == "1"
-
-    def is_no(self, form_name, field_name) -> bool | None:
-        form = self.forms.get(form_name)
-        if not form:
-            return False
-        return form.get(field_name) == "0"
-
     @property
     def has_partner(self):
-        return self.is_yes("about-you", "has_partner") and not self.is_yes(
-            "about-you", "are_you_in_a_dispute"
-        )
+        return self.forms.get("about-you", {}).get(
+            "has_partner", False
+        ) and not self.forms.get("about-you", {}).get("are_you_in_a_dispute", False)
 
     @property
     def is_employed(self):
-        return self.is_yes("about-you", "is_employed")
+        return self.forms.get("about-you", {}).get("is_employed", False)
 
     @property
     def is_self_employed(self):
-        return self.is_yes("about-you", "is_self_employed")
+        return self.forms.get("about-you", {}).get("is_self_employed", False)
 
     @property
     def is_employed_or_self_employed(self):
-        return self.is_yes("about-you", "is_employed") or self.is_yes(
-            "about-you", "is_self_employed"
-        )
+        return self.forms.get("about-you", {}).get("is_employed") or self.forms.get(
+            "about-you", {}
+        ).get("is_self_employed", False)
 
     @property
     def is_partner_employed(self):
         if not self.has_partner:
             return False
-        return self.is_yes("about-you", "partner_is_employed")
+        return self.forms.get("about-you", {}).get("partner_is_employed")
 
     @property
     def is_partner_self_employed(self):
         if not self.has_partner:
             return False
-        return self.is_yes("about-you", "partner_is_self_employed")
+        return self.forms.get("about-you", {}).get("partner_is_self_employed")
 
     @property
     def has_savings(self):
-        return self.is_yes("about-you", "have_savings")
+        return self.forms.get("about-you", {}).get("have_savings", False)
 
     @property
     def has_valuables(self):
-        return self.is_yes("about-you", "have_valuables")
+        return self.forms.get("about-you", {}).get("have_valuables", False)
 
     @property
     def has_children(self) -> bool:
-        return self.is_yes("about-you", "have_children")
+        return self.forms.get("about-you", {}).get("have_children", False)
 
     @property
     def has_dependants(self) -> bool:
-        return self.is_yes("about-you", "have_dependents")
+        return self.forms.get("about-you", {}).get("have_dependents", False)
 
     @property
     def on_benefits(self) -> bool:
-        return self.is_yes("about-you", "on_benefits")
+        return self.forms.get("about-you", {}).get("on_benefits", False)
 
     @property
     def is_eligible_for_child_benefits(self) -> bool:

--- a/app/static/src/js/conditional-questions.js
+++ b/app/static/src/js/conditional-questions.js
@@ -8,14 +8,14 @@
  *  {{ form.partner_is_employed(params={
  *         "attributes": {
  *             "data-controlled-by": "has_partner",
- *             "data-show-value": "yes"
+ *             "data-show-value": "True"
  *         }
  *     }) }}
  *
- *   The second question will only display when has_partner has a value of "yes" .
+ *   The second question will only display when has_partner has a value of "True" .
  *
  *   Note: This only controls whether the element should be displayed on the page, to skip the validation for this field
- *   add the ValidateIf("has_partner", "yes") validator to the start of the validation list for the field.
+ *   add the ValidateIf("has_partner", True) validator to the start of the validation list for the field.
  */
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/templates/means_test/about-you.html
+++ b/app/templates/means_test/about-you.html
@@ -75,7 +75,7 @@
     {{ form.partner_is_employed(params={
         "attributes": {
             "data-controlled-by": "are_you_in_a_dispute",
-            "data-show-value": "0"
+            "data-show-value": "False"
         }
     }) }}
 
@@ -84,7 +84,7 @@
     {{ form.partner_is_self_employed(params={
         "attributes": {
             "data-controlled-by": "are_you_in_a_dispute",
-            "data-show-value": "0"
+            "data-show-value": "False"
         }
     }) }}
 

--- a/app/templates/means_test/additional-benefits.html
+++ b/app/templates/means_test/additional-benefits.html
@@ -11,7 +11,7 @@
     {{ form.csrf_token }}
 
     {{ form.benefits }}
-    {{ form.render_conditional(form.other_benefits, form.total_other_benefit, "1") }}
+    {{ form.render_conditional(form.other_benefits, form.total_other_benefit, "True") }}
 
     {{ form.submit }}
 {% endblock %}

--- a/tests/functional_tests/means_test/test_benefits_page.py
+++ b/tests/functional_tests/means_test/test_benefits_page.py
@@ -1,7 +1,6 @@
 import pytest
 from flask import url_for
 from playwright.sync_api import Page, expect
-from app.means_test import YES, NO
 
 
 next_page_heading = "Check your answers and confirm"
@@ -105,7 +104,7 @@ def test_child_benefits_available_have_children(page: Page, client):
     with client.session_transaction() as session:
         # update the session
         session.get_eligibility().add(
-            "about-you", {"have_children": YES, "have_dependents": NO}
+            "about-you", {"have_children": True, "have_dependents": False}
         )
 
     url = url_for("means_test.benefits", _external=True)
@@ -123,7 +122,7 @@ def test_child_benefits_available_have_dependents(page: Page, client):
     with client.session_transaction() as session:
         # update the session
         session.get_eligibility().add(
-            "about-you", {"have_children": NO, "have_dependents": YES}
+            "about-you", {"have_children": False, "have_dependents": True}
         )
 
     url = url_for("means_test.benefits", _external=True)

--- a/tests/unit_tests/means_test/test_property.py
+++ b/tests/unit_tests/means_test/test_property.py
@@ -7,18 +7,18 @@ from app.means_test.forms.property import PropertyPayload, validate_single_main_
 def test_property_payload_with_valid_data():
     form_data = {
         "submit": False,
-        "is_main_home": "True",
-        "other_shareholders": "0",
+        "is_main_home": True,
+        "other_shareholders": False,
         "property_value": 230000,
         "mortgage_remaining": 100000,
         "mortgage_payments": 500,
-        "is_rented": "1",
+        "is_rented": True,
         "rent_amount": {
             "per_interval_value": 500,
             "per_interval_value_pounds": 50.0,
             "interval_period": "per_week",
         },
-        "in_dispute": "False",
+        "in_dispute": False,
         "csrf_token": None,
     }
     expected_property_value = 23000000
@@ -31,8 +31,8 @@ def test_property_payload_with_valid_data():
     assert payload["value"] == expected_property_value
     assert payload["mortgage_left"] == expected_mortgage_remaining
     assert payload["share"] == expected_share
-    assert payload["disputed"] == "False"
-    assert payload["main"] == "True"
+    assert payload["disputed"] is False
+    assert payload["main"]
 
     rent = payload["rent"]["per_interval_value"]
     assert rent == expected_rent
@@ -41,18 +41,18 @@ def test_property_payload_with_valid_data():
 def test_property_payload_with_missing_rent():
     form_data = {
         "submit": False,
-        "is_main_home": "True",
-        "other_shareholders": "0",
+        "is_main_home": True,
+        "other_shareholders": False,
         "property_value": 230000,
         "mortgage_remaining": 100000,
         "mortgage_payments": 500,
-        "is_rented": "1",
+        "is_rented": True,
         "rent_amount": {
             "per_interval_value": None,
             "per_interval_value_pounds": None,
             "interval_period": None,
         },
-        "in_dispute": "False",
+        "in_dispute": False,
         "csrf_token": None,
     }
 
@@ -66,8 +66,8 @@ def test_property_payload_with_missing_rent():
     assert payload["value"] == expected_property_value
     assert payload["mortgage_left"] == expected_mortgage_remaining
     assert payload["share"] == expected_share
-    assert payload["disputed"] == "False"
-    assert payload["main"] == "True"
+    assert payload["disputed"] is False
+    assert payload["main"]
 
     rent = payload["rent"]
     assert rent == expected_rent
@@ -86,8 +86,8 @@ class MockField:
 def test_validate_single_main_home_multiple_main_homes():
     """Test with multiple main homes."""
     form_data = [
-        {"is_main_home": "True"},
-        {"is_main_home": "True"},
+        {"is_main_home": True},
+        {"is_main_home": True},
     ]
     form = MockForm(form_data)
 
@@ -99,30 +99,30 @@ def test_validate_single_main_home_multiple_main_homes():
 
 
 def test_property_add():
-    form_data = [{"is_main_home": "True"}]
+    form_data = [{"is_main_home": True}]
     form = MockForm(form_data)
 
-    form.properties.data.append({"is_main_home": "False"})
+    form.properties.data.append({"is_main_home": False})
 
     assert len(form.properties.data) == 2
-    assert form.properties.data[1]["is_main_home"] == "False"
+    assert form.properties.data[1]["is_main_home"] is False
 
 
 def test_property_remove_second():
-    form_data = [{"is_main_home": "True"}, {"is_main_home": "False"}]
+    form_data = [{"is_main_home": True}, {"is_main_home": False}]
     form = MockForm(form_data)
 
     form.properties.data.pop(1)
 
     assert len(form.properties.data) == 1
-    assert form.properties.data[0]["is_main_home"] == "True"
+    assert form.properties.data[0]["is_main_home"]
 
 
 def test_property_remove_third():
     form_data = [
-        {"is_main_home": "True"},
-        {"is_main_home": "False"},
-        {"is_main_home": "False"},
+        {"is_main_home": True},
+        {"is_main_home": False},
+        {"is_main_home": False},
     ]
     form = MockForm(form_data)
 

--- a/tests/unit_tests/means_test/test_session.py
+++ b/tests/unit_tests/means_test/test_session.py
@@ -1,36 +1,16 @@
 from app.session import Eligibility
 
 
-def test_is_yes():
-    eligibility = Eligibility(forms={"form1": {"field1": "1"}}, _notes={})
-
-    assert eligibility.is_yes("form1", "field1")
-
-    assert not eligibility.is_yes("form1", "field2")
-
-    assert not eligibility.is_yes("form2", "field1")
-
-
-def test_is_no():
-    eligibility = Eligibility(forms={"form1": {"field1": "0"}}, _notes={})
-
-    assert eligibility.is_no("form1", "field1")
-
-    assert not eligibility.is_no("form1", "field2")
-
-    assert not eligibility.is_no("form2", "field1")
-
-
 def test_has_partner():
     eligibility = Eligibility(
-        forms={"about-you": {"has_partner": "1", "are_you_in_a_dispute": "0"}},
+        forms={"about-you": {"has_partner": True, "are_you_in_a_dispute": False}},
         _notes={},
     )
 
     assert eligibility.has_partner
 
     eligibility = Eligibility(
-        forms={"about-you": {"has_partner": "1", "are_you_in_a_dispute": "1"}},
+        forms={"about-you": {"has_partner": True, "are_you_in_a_dispute": True}},
         _notes={},
     )
 
@@ -39,7 +19,7 @@ def test_has_partner():
 
 def test_employment_status():
     eligibility = Eligibility(
-        forms={"about-you": {"is_employed": "1", "is_self_employed": "0"}}, _notes={}
+        forms={"about-you": {"is_employed": True, "is_self_employed": False}}, _notes={}
     )
 
     assert eligibility.is_employed
@@ -53,10 +33,10 @@ def test_partner_employment():
     eligibility = Eligibility(
         forms={
             "about-you": {
-                "has_partner": "1",
-                "are_you_in_a_dispute": "0",
-                "partner_is_employed": "1",
-                "partner_is_self_employed": "0",
+                "has_partner": True,
+                "are_you_in_a_dispute": False,
+                "partner_is_employed": True,
+                "partner_is_self_employed": False,
             }
         },
         _notes={},
@@ -66,7 +46,7 @@ def test_partner_employment():
 
     assert not eligibility.is_partner_self_employed
 
-    eligibility = Eligibility(forms={"about-you": {"has_partner": "0"}}, _notes={})
+    eligibility = Eligibility(forms={"about-you": {"has_partner": False}}, _notes={})
 
     assert not eligibility.is_partner_employed
 

--- a/tests/unit_tests/means_test/test_views_summary.py
+++ b/tests/unit_tests/means_test/test_views_summary.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from flask_babel import lazy_gettext as _
 from app.means_test.views import CheckYourAnswers, ReviewForm
-from app.means_test import YES, NO
 from app.session import Eligibility
 from app.categories.models import CategoryAnswer
 from app.categories.constants import DISCRIMINATION, HOUSING
@@ -16,11 +15,11 @@ def mock_session_get_eligibility():
         **{
             "forms": {
                 "about-you": {
-                    "has_partner": NO,
-                    "on_benefits": YES,
-                    "have_children": NO,
-                    "have_dependents": NO,
-                    "own_property": NO,
+                    "has_partner": False,
+                    "on_benefits": True,
+                    "have_children": False,
+                    "have_dependents": False,
+                    "own_property": False,
                 },
                 "benefits": {"benefits": ["employment_support", "universal_credit"]},
             }


### PR DESCRIPTION
## What does this pull request do?

- Refactors the means test to use `YesNoField`s rather than `RadioFields` with Yes/ No as their values, this makes checking the users input simpler later

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
