### PR TITLE
Enable training backend connection and disable staging whitelist

### DIFF
--- a/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
 {{- $fullName := include "laa-access-civil-legal-aid.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -17,7 +17,7 @@ metadata:
     {{- if .Values.ingress.cluster.name }}
     external-dns.alpha.kubernetes.io/set-identifier: "{{ $fullName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
     external-dns.alpha.kubernetes.io/aws-weight: "{{- .Values.ingress.cluster.weight -}}"
-    {{- if .Values.whitelist.enabled -}}
+    {{- if .Values.whitelist.enabled }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "laa-access-civil-legal-aid.whitelist" . }}"
     {{- end }}
     {{- end }}

--- a/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/templates/ingress.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- if .Values.ingress.cluster.name }}
     external-dns.alpha.kubernetes.io/set-identifier: "{{ $fullName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
     external-dns.alpha.kubernetes.io/aws-weight: "{{- .Values.ingress.cluster.weight -}}"
+    {{- if .Values.whitelist.enabled -}}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "laa-access-civil-legal-aid.whitelist" . }}"
+    {{- end }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/helm_deploy/laa-access-civil-legal-aid/values.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values.yaml
@@ -44,6 +44,9 @@ ingress:
     weight: '100'
   tls: []
 
+whitelist:
+  enabled: true
+
 resources: {}
 
 autoscaling:

--- a/helm_deploy/laa-access-civil-legal-aid/values/values-dev.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-dev.yaml
@@ -14,6 +14,9 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
 
+whitelist:
+  enabled: true
+
 envVars:
   DEBUG:
     value: "True"

--- a/helm_deploy/laa-access-civil-legal-aid/values/values-production.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-production.yaml
@@ -9,6 +9,9 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
 
+whitelist:
+  enabled: true
+
 envVars:
   CLA_BACKEND_URL:
     value: "http://cla-backend-app.laa-cla-backend-production.svc.cluster.local"

--- a/helm_deploy/laa-access-civil-legal-aid/values/values-staging.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-staging.yaml
@@ -9,6 +9,9 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
 
+whitelist:
+  enabled: false
+
 envVars:
   CLA_BACKEND_URL:
-    value: "http://cla-backend-app.laa-cla-backend-staging.svc.cluster.local"
+    value: "http://cla-backend-app.laa-cla-backend-training.svc.cluster.local"

--- a/helm_deploy/laa-access-civil-legal-aid/values/values-uat.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-uat.yaml
@@ -9,6 +9,9 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
 
+whitelist:
+  enabled: true
+
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:
   DEBUG:


### PR DESCRIPTION
## What does this pull request do?

- Switches the staging site to connect to the training CLA Backend environment, ahead of tomorrows testing
- Disables the whitelist on the beta site

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
