### PR TITLE
LGA-3544: Submit scope traversal details

### DIFF
--- a/app/contact/forms.py
+++ b/app/contact/forms.py
@@ -590,6 +590,7 @@ class ContactUsForm(FlaskForm):
                 else self.data.get("other_language").upper(),
                 "notes": self.data.get("other_adaptation"),
             },
+            "client_notes": self.data.get("extra_notes"),
         }
         if self.data.get("contact_type") == "callback":
             payload["requires_action_at"] = requires_action_at

--- a/app/contact/urls.py
+++ b/app/contact/urls.py
@@ -25,7 +25,7 @@ class EligibleContactUsPage(ContactUs):
 bp.add_url_rule(
     "/eligible",
     view_func=EligibleContactUsPage.as_view(
-        "eligible", template="contact/eligible.html", attach_eligiblity_data=True
+        "eligible", template="contact/eligible.html", attach_eligibility_data=True
     ),
 )
 
@@ -48,7 +48,7 @@ def geocode(postcode):
 
 bp.add_url_rule(
     "/contact-us",
-    view_func=ContactUs.as_view("contact_us", attach_eligiblity_data=False),
+    view_func=ContactUs.as_view("contact_us", attach_eligibility_data=False),
 )
 
 bp.add_url_rule("/confirmation", view_func=ConfirmationPage.as_view("confirmation"))

--- a/app/contact/views.py
+++ b/app/contact/views.py
@@ -37,21 +37,20 @@ class ContactUs(View):
     methods = ["GET", "POST"]
     template = "contact/contact.html"
 
-    def __init__(self, template: str = None, attach_eligiblity_data: bool = False):
+    def __init__(self, template: str = None, attach_eligibility_data: bool = False):
         if template:
             self.template = template
-        self.attach_eligiblity_data = attach_eligiblity_data
+        self.attach_eligibility_data = attach_eligibility_data
 
     def dispatch_request(self):
         form = ContactUsForm()
         form_progress = MeansTest(ContactUsForm, "Contact us").get_form_progress(form)
         if form.validate_on_submit():
             payload = form.get_payload()
-            # Add the extra notes to the eligibility object
-            if not self.attach_eligiblity_data:
+            if not self.attach_eligibility_data:
                 session.clear_eligibility()
 
-            self._append_notes_to_eligibility_check(form.data.get("extra_notes"))
+            payload["scope_traversal"] = session.get_scope_traversal()
 
             session["case_reference"] = cla_backend.post_case(payload=payload)[
                 "reference"

--- a/app/session.py
+++ b/app/session.py
@@ -332,6 +332,43 @@ class Session(SecureCookieSession):
 
         self["category_answers"] = answers
 
+    def get_scope_traversal(self):
+        """Used to populate the users' case data with their answers from this service."""
+
+        def get_users_answers(answers: list[CategoryAnswer]) -> list[dict]:
+            """Only get the fields that we need to store in the backend."""
+            return [
+                {
+                    "question": answer.question,
+                    "answer": answer.answer_label,
+                    "type": answer.question_type,
+                }
+                for answer in answers
+            ]
+
+        category_information = (
+            {"name": self.category.title._args[0], "code": self.category.chs_code}
+            if self.category
+            else None
+        )
+
+        subcategory_information = (
+            {
+                "name": self.subcategory.title._args[
+                    0
+                ],  # Get the non-translated string
+                "description": self.subcategory.description._args[0],
+            }
+            if self.subcategory
+            else None
+        )
+
+        return {
+            "scope_answers": get_users_answers(self.category_answers),
+            "category": category_information,
+            "subcategory": subcategory_information,
+        }
+
 
 class SessionInterface(SecureCookieSessionInterface):
     session_class = Session

--- a/app/templates/categories/in-scope.html
+++ b/app/templates/categories/in-scope.html
@@ -37,10 +37,8 @@
 
         <h2 class="govuk-heading-m">{% trans %}When you do not need to complete the financial assessment{% endtrans %}</h2>
 
-        {% set contact_us_link %}
-            <a class="govuk-link" href={{ url_for('contact.contact_us') }}>contact CLA</a>
-        {% endset %}
-        <p class="govuk-body">{% trans %}You should {{ contact_us_link }}  without completing the financial assessment if you are:{% endtrans %}</p>
+        {% set contact_us_link %}<a class="govuk-link" href={{ url_for('contact.contact_us') }}>contact CLA</a>{% endset %}
+        <p class="govuk-body">{% trans %}You should {{ contact_us_link }} without completing the financial assessment if you are:{% endtrans %}</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>{% trans %}under 18{% endtrans %}</li>

--- a/tests/functional_tests/contact/test_confirmation.py
+++ b/tests/functional_tests/contact/test_confirmation.py
@@ -71,7 +71,7 @@ def test_housing_category(page: Page):
     page.get_by_role("link", name="Housing, homelessness, losing").click()
     page.get_by_role("link", name="Homelessness").click()
     page.get_by_role("paragraph").filter(
-        has_text="Fill in the ' contact CLA '"
+        has_text="Fill in the 'contact CLA'"
     ).get_by_role("link").click()
     page.get_by_role("textbox", name="Your full name").fill("John Doe")
     page.get_by_role("radio", name="I will call you").check()

--- a/tests/unit_tests/contact/test_views.py
+++ b/tests/unit_tests/contact/test_views.py
@@ -1,28 +1,29 @@
 from unittest.mock import patch, MagicMock
 from flask import url_for
-from app.session import Session
 from app.contact.forms import ReasonsForContactingForm
+from app.contact.urls import EligibleContactUsPage
 from app.contact.views import ContactUs
-from app.contact.urls import EligibleContactUsPage, EligibilityState
+from app.means_test.constants import EligibilityState
 from app.means_test.views import MeansTest
+from app.session import Session
 
 
 class TestContactUsView:
     def test_init_with_default_template(self):
         view = ContactUs()
         assert view.template == "contact/contact.html"
-        assert view.attach_eligiblity_data is False
+        assert view.attach_eligibility_data is False
 
     def test_init_with_custom_template(self):
         custom_template = "custom/template.html"
         view = ContactUs(template=custom_template)
         assert view.template == custom_template
-        assert view.attach_eligiblity_data is False
+        assert view.attach_eligibility_data is False
 
     def test_init_with_attach_eligibility_data(self):
-        view = ContactUs(attach_eligiblity_data=True)
+        view = ContactUs(attach_eligibility_data=True)
         assert view.template == "contact/contact.html"
-        assert view.attach_eligiblity_data is True
+        assert view.attach_eligibility_data is True
 
     @patch("app.contact.views.ContactUsForm")
     @patch("app.contact.views.MeansTest")
@@ -50,10 +51,8 @@ class TestContactUsView:
     @patch("app.contact.views.redirect")
     @patch("app.contact.views.cla_backend")
     @patch("app.contact.views.notify")
-    @patch.object(ContactUs, "_append_notes_to_eligibility_check")
     def test_post_request_success(
         self,
-        mock_append_notes,
         mock_notify,
         mock_cla_backend,
         mock_redirect,
@@ -81,7 +80,6 @@ class TestContactUsView:
         view.dispatch_request()
 
         mock_cla_backend.post_case.assert_called_once()
-        mock_append_notes.assert_called_once_with("Some notes")
         mock_notify.create_and_send_confirmation_email.assert_called_once()
         mock_redirect.assert_called_once_with(url_for("contact.confirmation"))
 
@@ -133,35 +131,6 @@ class TestContactUsView:
             client.post("/contact-us", data=form_data)
 
             mock_attach_rfc_to_case.assert_called_once_with("AB-1234-5678", "1234")
-
-    @patch("app.contact.views.update_means_test")
-    def test_append_notes_to_eligibility_check_with_valid_notes(
-        self, mock_update_means_test, app, client
-    ):
-        notes_data = "User notes"
-
-        view = ContactUs()
-        view._append_notes_to_eligibility_check(notes_data)
-
-        mock_update_means_test.assert_called_once()
-        eligibility_check = mock_update_means_test.mock_calls[0][1][0]
-        assert "notes" in eligibility_check
-        assert eligibility_check["notes"] == "User problem:\nUser notes"
-
-    @patch("app.contact.views.update_means_test")
-    def test_append_notes_to_eligibility_check_with_empty_notes(
-        self, mock_update_means_test, app, client
-    ):
-        # Test with empty string
-        view = ContactUs()
-        view._append_notes_to_eligibility_check("")
-
-        mock_update_means_test.assert_not_called()
-
-        # Test with None
-        view._append_notes_to_eligibility_check(None)
-
-        mock_update_means_test.assert_not_called()
 
     @patch("app.contact.views.cla_backend.update_reasons_for_contacting")
     def test_attaching_rfc_to_case(self, mock_update_rfc, app, client):


### PR DESCRIPTION
## What does this pull request do?

- Submits the users' scope traversal to CLA Backend
- Submits the users' financial eligibility status to CLA Backend
- Submits the users' notes to the new client notes field of `legalaid.Case`

## Any other changes that would benefit highlighting?

- Fixes some erroneous whitespace around the "Contact CLA" link on the "In-scope" page

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
