### PR TITLE
LGA-3669: Fix SEND session expired bug

### DIFF
--- a/app/categories/constants.py
+++ b/app/categories/constants.py
@@ -327,6 +327,7 @@ EDUCATION = Category(
                 "Help with schools, other education settings and local authorities. Includes help with education, health and care plans (EHCP) or if a child’s needs are not being met."
             ),
             code="child_young_person",
+            in_scope=True,
         ),
         "tribunals": Category(
             title=_("SEND tribunals"),

--- a/tests/functional_tests/categories/send/test_send.py
+++ b/tests/functional_tests/categories/send/test_send.py
@@ -70,3 +70,27 @@ class TestSendLandingPage:
         expect(
             page.get_by_role("heading", name=legalaid_available_page)
         ).to_be_visible()
+
+    def test_help_with_a_child_in_care_form_yes(self, page: Page):
+        page.get_by_role(
+            "link", name="Special educational needs and disability (SEND)"
+        ).click()
+        page.get_by_role(
+            "link", name="Help with a child or young person's SEND"
+        ).click()
+        page.get_by_label("Yes").check()
+        page.get_by_role("button", name="Continue").click()
+        expect(page.get_by_role("heading", name=contact_page_heading)).to_be_visible()
+
+    def test_help_with_a_child_in_care_form_no(self, page: Page):
+        page.get_by_role(
+            "link", name="Special educational needs and disability (SEND)"
+        ).click()
+        page.get_by_role(
+            "link", name="Help with a child or young person's SEND"
+        ).click()
+        page.get_by_label("No").check()
+        page.get_by_role("button", name="Continue").click()
+        expect(
+            page.get_by_role("heading", name=legalaid_available_page)
+        ).to_be_visible()

--- a/tests/unit_tests/categories/test_session.py
+++ b/tests/unit_tests/categories/test_session.py
@@ -1,4 +1,4 @@
-from app.categories.constants import Category, HOUSING, EDUCATION
+from app.categories.constants import Category, HOUSING, COMMUNITY_CARE
 import pytest
 from flask import url_for
 from app.categories.models import CategoryAnswer, QuestionType
@@ -118,7 +118,7 @@ def test_in_scope(client):
         answer_label="Car",
         next_page="categories.index",
         question_page="categories.housing.homelessness",
-        category=EDUCATION.sub.child_young_person,
+        category=COMMUNITY_CARE.sub.problems_with_quality_of_care,
     )
     with client.session_transaction() as session:
         assert session.in_scope is False


### PR DESCRIPTION
## What does this pull request do?

- Fixes an issue where the user journey:
Help with a child or young person's SEND → Is this about a child who is or has been in care? → No
Was incorrectly classified as not in-scope.

## Any other changes that would benefit highlighting?

- Updates a unit test that needs to reference and out-of-scope category

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
