### PR TITLE
LGA-3676 Child Benefit Field Fix

### DIFF
--- a/app/means_test/payload.py
+++ b/app/means_test/payload.py
@@ -82,7 +82,11 @@ class AboutYouPayload(dict):
 class YourBenefitsPayload(dict):
     @classmethod
     def default(cls):
-        return {"specific_benefits": {}, "on_passported_benefits": False}
+        return {
+            "specific_benefits": {},
+            "on_passported_benefits": False,
+            "you": {"income": {"child_benefits": MoneyInterval(0)}},
+        }
 
     def __init__(self, form_data=None):
         super(YourBenefitsPayload, self).__init__()

--- a/app/means_test/payload.py
+++ b/app/means_test/payload.py
@@ -119,7 +119,7 @@ class YourBenefitsPayload(dict):
                 return form_data.get(field)
 
             payload["you"] = {
-                "income": {"child_benefits": MoneyInterval(val("child_benefit"))}
+                "income": {"child_benefits": MoneyInterval(val("child_benefits"))}
             }
 
         self.update(payload)

--- a/tests/functional_tests/means_test/test_review.py
+++ b/tests/functional_tests/means_test/test_review.py
@@ -227,7 +227,7 @@ def test_change_answer_nolonger_passported(page: Page, complete_benefits_form):
     expect(page).to_have_title("Your money coming in - GOV.UK")
     answers["Your money coming in"] = {
         "Maintenance received": {
-            "Amount": "120.56",
+            "Amount": "1420.56",
             "Frequency": "per month",
             "prefix": "maintenance_received",
         },
@@ -237,7 +237,7 @@ def test_change_answer_nolonger_passported(page: Page, complete_benefits_form):
             "prefix": "pension",
         },
         "Any other income": {
-            "Amount": "2000.00",
+            "Amount": "10.00",
             "Frequency": "per month",
             "prefix": "other_income",
         },


### PR DESCRIPTION
## What does this pull request do?

Changes the name of the val field referenced so that it can be passed into CHS.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
