### PR TITLE
LGA-3650 Remember 0 Values Bug

### DIFF
--- a/app/means_test/money_interval.py
+++ b/app/means_test/money_interval.py
@@ -85,6 +85,8 @@ class MoneyInterval(dict):
             return False
 
     def amount_to_pounds(self):
+        if self["per_interval_value"] == 0:
+            return 0
         if not self["per_interval_value"]:
             return None
         return self["per_interval_value"] / 100


### PR DESCRIPTION
## What does this pull request do?

Remembers 0 values if 0 values are entered instead of None.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
