### PR TITLE
LGA-3674: Fix being able to go back from the confirmation page

### DIFF
--- a/app/contact/views.py
+++ b/app/contact/views.py
@@ -23,6 +23,9 @@ class ReasonForContacting(View):
         if request.method == "GET":
             form.referrer.data = request.referrer or "Unknown"
         if form.validate_on_submit():
+            # If the user has already raised a case we want to ensure their information is not included in multiple cases.
+            if session.get("case_reference"):
+                session.clear()
             result = cla_backend.post_reasons_for_contacting(form=form)
             next_step = form.next_step_mapping.get("*")
             logger.info("RFC Created Reference: %s", result.get("reference"))
@@ -42,6 +45,9 @@ class ContactUs(View):
         self.attach_eligibility_data = attach_eligibility_data
 
     def dispatch_request(self):
+        if session.get("case_reference", None):
+            logger.info("FAILED contact page due to invalid session")
+            return redirect(url_for("main.session_expired"))
         form = ContactUsForm()
         form_progress = MeansTest(ContactUsForm, "Contact us").get_form_progress(form)
         if form.validate_on_submit():

--- a/tests/functional_tests/contact/test_contact.py
+++ b/tests/functional_tests/contact/test_contact.py
@@ -250,3 +250,20 @@ def test_postcode_field(page: Page, contact_answers: dict):
     expect(
         page.get_by_role("heading", name="Your details have been submitted")
     ).to_be_visible()
+
+
+@pytest.mark.usefixtures("live_server")
+def test_existing_case_ref_leads_to_session_expired(page: Page):
+    """Test that going back after creating a case leads to the session expired page."""
+    page.get_by_role("link", name="Contact us").click()
+    page.get_by_role("button", name="Continue to contact CLA").click()
+    page.get_by_role("textbox", name="Your full name").fill("John Doe")
+    page.get_by_role("radio", name="I will call you").check()
+    page.get_by_role("button", name="Submit details").click()
+    expect(
+        page.get_by_role("heading", name="Your details have been submitted")
+    ).to_be_visible()
+    page.go_back()
+    expect(
+        page.get_by_role("heading", name="You’ve reached the end of this service")
+    ).to_be_visible()

--- a/tests/unit_tests/contact/test_views.py
+++ b/tests/unit_tests/contact/test_views.py
@@ -28,7 +28,9 @@ class TestContactUsView:
     @patch("app.contact.views.ContactUsForm")
     @patch("app.contact.views.MeansTest")
     @patch("app.contact.views.render_template")
-    def test_get_request(self, mock_render_template, mock_means_test, mock_form):
+    def test_get_request(
+        self, mock_render_template, mock_means_test, mock_form, app, client
+    ):
         mock_form_instance = MagicMock()
         mock_form.return_value = mock_form_instance
         mock_form_instance.validate_on_submit.return_value = False
@@ -87,7 +89,7 @@ class TestContactUsView:
     @patch("app.contact.views.render_template")
     @patch.object(MeansTest, "get_form_progress")
     def test_post_request_validation_failure(
-        self, mock_means_test, mock_render_template, mock_form
+        self, mock_means_test, mock_render_template, mock_form, app, client
     ):
         mock_form_instance = MagicMock()
         mock_form.return_value = mock_form_instance
@@ -190,3 +192,12 @@ def test_eligible_view_failure_no_ec_reference(app):
             assert mock_is_eligible.called is False
             assert response.status_code == 302
             assert response.location == url_for("main.session_expired")
+
+
+def test_existing_case_ref_leads_to_session_expired(app, client):
+    with client.session_transaction() as session:
+        session["case_reference"] = "AB-1234-5678"
+
+    response = client.get("/contact-us")
+    assert response.status_code == 302
+    assert response.location == url_for("main.session_expired")

--- a/tests/unit_tests/contact/test_views.py
+++ b/tests/unit_tests/contact/test_views.py
@@ -33,7 +33,9 @@ class TestContactUsView:
     @patch("app.contact.views.ContactUsForm")
     @patch("app.contact.views.MeansTest")
     @patch("app.contact.views.render_template")
-    def test_get_request(self, mock_render_template, mock_means_test, mock_form, app, client):
+    def test_get_request(
+        self, mock_render_template, mock_means_test, mock_form, app, client
+    ):
         mock_form_instance = MagicMock()
         mock_form.return_value = mock_form_instance
         mock_form_instance.validate_on_submit.return_value = False
@@ -170,7 +172,9 @@ class TestFastTrackedContactUsView:
             response = view.dispatch_request()
             assert response.status_code == 302
             assert response.location == url_for("main.session_expired")
-            
+            assert mock_ensure_in_scope.called is True
+            assert mock_dispatch_request.called is False
+
     @patch("app.contact.views.ContactUs.dispatch_request", return_value=None)
     @patch("app.contact.views.FastTrackedContactUs.ensure_in_scope", return_value=None)
     def test_dispatch_request_success(
@@ -189,9 +193,7 @@ class TestFastTrackedContactUsView:
             financial_status, financial_reason = view.get_financial_eligibility_status()
             assert financial_status == FinancialAssessmentStatus.FAST_TRACK
             assert financial_reason == FinancialAssessmentReason.HARM
-            assert mock_ensure_in_scope.called is True
-            assert mock_dispatch_request.called is False
-               
+
 
 @patch("app.contact.views.is_eligible", return_value=EligibilityState.YES)
 @patch("app.contact.views.ContactUs.dispatch_request")
@@ -227,7 +229,8 @@ def test_eligible_view_failure_no_ec_reference(mock_is_eligible, app):
         assert mock_is_eligible.called is False
         assert response.status_code == 302
         assert response.location == url_for("main.session_expired")
-        
+
+
 def test_existing_case_ref_leads_to_session_expired(app, client):
     with client.session_transaction() as session:
         session["case_reference"] = "AB-1234-5678"


### PR DESCRIPTION
## What does this pull request do?

- Adds traversal protection to the contact us page.

https://github.com/user-attachments/assets/56a32863-3b11-4a5b-a10d-d910cca6f733

## Any other changes that would benefit highlighting?

- Clears the users session on submitting the reasons for contacting form, as we do not want users to be able to submit the same case details multiple times.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
