### PR TITLE
Bug/LGA-3681 Repair GTM Anon ID

### DIFF
--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -35,6 +35,8 @@ def detect_gtm_anon_id():
         session["gtm_anon_id"] = str(uuid.uuid4())
         expiration_date = datetime.now(timezone.utc) + timedelta(days=730)
         response.set_cookie(
-            "gtm_anon_id", session.get("gtm_anon_id"), expires=expiration_date
+            "gtm_anon_id",
+            session.get("gtm_anon_id"),
+            expires=expiration_date,
         )
         return response

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -33,7 +33,7 @@ def detect_gtm_anon_id():
     @after_this_request
     def remember_gtm_anon_id(response):
         session["gtm_anon_id"] = str(uuid.uuid4())
-        expiration_date = datetime.now(timezone.utc) + timedelta(days=180)
+        expiration_date = datetime.now(timezone.utc) + timedelta(days=730)
         response.set_cookie(
             "gtm_anon_id",
             session.get("gtm_anon_id"),

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -3,6 +3,7 @@ from app.main import bp
 from datetime import datetime, timedelta, timezone
 import uuid
 import re
+import json
 
 
 @bp.app_context_processor
@@ -21,22 +22,27 @@ def get_gtm_anon_id_from_cookie():
 
 @bp.before_app_request
 def detect_gtm_anon_id():
-    # gtm_anon_id is used to track user anonymously across services for Google Tag Manager.
+    cookies_policy = request.cookies.get("cookies_policy", "{}")
+
+    try:
+        policy_dict = json.loads(cookies_policy)
+    except ValueError:
+        policy_dict = {}
+
+    if policy_dict.get("analytics") != "yes":
+        return
+
     if "gtm_anon_id" in session:
         return
 
-    anon_id_cookie = get_gtm_anon_id_from_cookie()
-    if anon_id_cookie:
-        session["gtm_anon_id"] = anon_id_cookie
-        return
+    session["gtm_anon_id"] = str(uuid.uuid4())
 
     @after_this_request
     def remember_gtm_anon_id(response):
-        session["gtm_anon_id"] = str(uuid.uuid4())
         expiration_date = datetime.now(timezone.utc) + timedelta(days=730)
         response.set_cookie(
             "gtm_anon_id",
-            session.get("gtm_anon_id"),
+            session["gtm_anon_id"],
             expires=expiration_date,
         )
         return response

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -34,7 +34,6 @@ def detect_gtm_anon_id():
     def remember_gtm_anon_id(response):
         session["gtm_anon_id"] = str(uuid.uuid4())
         expiration_date = datetime.now(timezone.utc) + timedelta(days=180)
-        print(expiration_date)
         response.set_cookie(
             "gtm_anon_id",
             session.get("gtm_anon_id"),

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -33,7 +33,8 @@ def detect_gtm_anon_id():
     @after_this_request
     def remember_gtm_anon_id(response):
         session["gtm_anon_id"] = str(uuid.uuid4())
-        expiration_date = datetime.now(timezone.utc) + timedelta(days=730)
+        expiration_date = datetime.now(timezone.utc) + timedelta(days=180)
+        print(expiration_date)
         response.set_cookie(
             "gtm_anon_id",
             session.get("gtm_anon_id"),

--- a/app/main/gtm.py
+++ b/app/main/gtm.py
@@ -33,7 +33,7 @@ def detect_gtm_anon_id():
     @after_this_request
     def remember_gtm_anon_id(response):
         session["gtm_anon_id"] = str(uuid.uuid4())
-        expiration_date = datetime.now(timezone.utc) + timedelta(days=30)
+        expiration_date = datetime.now(timezone.utc) + timedelta(days=730)
         response.set_cookie(
             "gtm_anon_id", session.get("gtm_anon_id"), expires=expiration_date
         )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -16,7 +16,6 @@ from flask import (
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import HTTPException
 from app.main import bp
-from app.main.gtm import get_gtm_anon_id_from_cookie
 from app.main.forms import CookiesForm
 
 
@@ -172,8 +171,6 @@ def online_safety():
 
 @bp.route("/session-expired", methods=["GET"])
 def session_expired():
-    session.clear()
-    session["GTM_ANON_ID"] = get_gtm_anon_id_from_cookie()
     return render_template("session_expired.html")
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -16,6 +16,7 @@ from flask import (
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import HTTPException
 from app.main import bp
+from app.main.gtm import get_gtm_anon_id_from_cookie
 from app.main.forms import CookiesForm
 
 
@@ -171,6 +172,8 @@ def online_safety():
 
 @bp.route("/session-expired", methods=["GET"])
 def session_expired():
+    session.clear()
+    session["gtm_anon_id"] = get_gtm_anon_id_from_cookie()
     return render_template("session_expired.html")
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -16,6 +16,7 @@ from flask import (
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import HTTPException
 from app.main import bp
+from app.main.gtm import get_gtm_anon_id_from_cookie
 from app.main.forms import CookiesForm
 
 
@@ -171,6 +172,8 @@ def online_safety():
 
 @bp.route("/session-expired", methods=["GET"])
 def session_expired():
+    session.clear()
+    session["GTM_ANON_ID"] = get_gtm_anon_id_from_cookie()
     return render_template("session_expired.html")
 
 

--- a/app/static/src/js/headscripts/gtm.js
+++ b/app/static/src/js/headscripts/gtm.js
@@ -8,8 +8,7 @@ function add_GTM() {
 
     // Standard GTM code
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-    console.log('here')
-    console.log(gtm_anon_id)
+
     // Insert our variable into data layer
     if(gtm_anon_id.length === 36) {
       window.dataLayer = window.dataLayer || [];

--- a/app/static/src/js/headscripts/gtm.js
+++ b/app/static/src/js/headscripts/gtm.js
@@ -10,7 +10,7 @@ function add_GTM() {
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
 
     // Insert our variable into data layer
-    if(typeof gtm_anon_id !== 'undefined' && gtm_anon_id.length === 36) {
+    if(gtm_anon_id.length === 36) {
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({ user_id: gtm_anon_id });
     }

--- a/app/static/src/js/headscripts/gtm.js
+++ b/app/static/src/js/headscripts/gtm.js
@@ -10,7 +10,7 @@ function add_GTM() {
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
 
     // Insert our variable into data layer
-    if(gtm_anon_id.length === 36) {
+    if(typeof gtm_anon_id === 'string' && gtm_anon_id.length === 36) {
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({ user_id: gtm_anon_id });
     }

--- a/app/static/src/js/headscripts/gtm.js
+++ b/app/static/src/js/headscripts/gtm.js
@@ -8,7 +8,8 @@ function add_GTM() {
 
     // Standard GTM code
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-
+    console.log('here')
+    console.log(gtm_anon_id)
     // Insert our variable into data layer
     if(gtm_anon_id.length === 36) {
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## What does this pull request do?

Amends the GTM anon ID so it updates to the datastream correctly. Also updates the expiry to 2 years (the browser maximum allowed expiry may reduce this).

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
