### PR TITLE
Set HTTPOnly to false on the cookies_policy cookie

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -134,7 +134,7 @@ def cookies():
             json.dumps(cookies_policy),
             max_age=31557600,
             secure=True,
-            httponly=True,
+            httponly=False,  # This needs to be read by the client so we set HTTPOnly to false.
             samesite="Strict",
         )
         return response


### PR DESCRIPTION
## What does this pull request do?

- Set HTTPOnly to false on the cookies_policy cookie when set via the cookie page form.
This resolves an issue where this cookie could not be read by the client resulting in JavaScript failing to load.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
