### PR TITLE
LGA-3692: Fix progress bar

### DIFF
--- a/app/templates/contact/eligible.html
+++ b/app/templates/contact/eligible.html
@@ -39,7 +39,7 @@
 {% block sidebar %}
   <div class="govuk-grid-column-one-third">
     <aside class="sidebar">
-      {{ means_test_progress(form_progress["steps"], form_progress["current_step"], 100) }}
+      {{ means_test_progress(form_progress["steps"], form_progress["current_step"], form_progress["completion_percentage"]) }}
     </aside>
   </div>
 {% endblock %}

--- a/app/templates/means_test/components/progress-bar.html
+++ b/app/templates/means_test/components/progress-bar.html
@@ -26,7 +26,7 @@
 
 {% macro progress(steps, current_step, completion_percentage) %}
 
-    {% set is_about_you_complete = (steps|selectattr('key', 'equalto', 'about-you')|list)[0].is_completed   %}
+    {% set show_collapsed_steps = (steps|selectattr('key', 'equalto', 'about-you')|list)[0].is_current and steps|length < 6 %}
     {% set has_remaining_forms = steps|rejectattr('is_completed')|list|length > 0 %}
     {% set is_contact_page = request.path.startswith('/result/') %}
 
@@ -37,7 +37,7 @@
             {# Steps to do #}
             {% for step in steps %}
                 {# Optional collapsed steps #}
-                {% if not is_about_you_complete and step.key == "review" %}
+                {% if show_collapsed_steps and step.key == "review" %}
                   <li class="progress-step m-collapsed">
                     {% for n in range(3) %}
                       <div class="step-name"></div>

--- a/app/templates/means_test/components/progress-bar.html
+++ b/app/templates/means_test/components/progress-bar.html
@@ -36,6 +36,14 @@
         <ul class="govuk-list progress-steps">
             {# Steps to do #}
             {% for step in steps %}
+                {# Optional collapsed steps #}
+                {% if not is_about_you_complete and step.title == "Check your answer and confirm" %}
+                  <li class="progress-step m-collapsed">
+                    {% for n in range(3) %}
+                      <div class="step-name"></div>
+                    {% endfor %}
+                  </li>
+                {% endif %}
                 <li class="progress-step
                     {% if step.is_completed %}completed-step {% endif %}
                     {% if step.is_current %}current-step{% endif %}">
@@ -52,37 +60,6 @@
                 {% endif %}
                 </li>
             {% endfor %}
-          {# Optional collapsed steps #}
-            {% if not is_about_you_complete %}
-              <li class="progress-step m-collapsed">
-                {% for n in range(3) %}
-                  <div class="step-name"></div>
-                {% endfor %}
-              </li>
-            {% endif %}
-          {# Review/ final steps #}
-            <li class="progress-step
-              {% if current_step.name == 'review' %}current-step{% endif %}
-              {% if not has_remaining_forms and current_step.name != 'review' %}completed-step{% endif %}">
-              {% if has_remaining_forms or is_contact_page or current_step.name == 'review'%}
-                <span class="step-name">
-              {% else %}
-                <a class="step-name" href="{{ url_for('means_test.review') }}">
-              {% endif %}
-                {{ step_status(not has_remaining_forms, current_step.name == 'review') }}
-                {% trans %}Check your answers and confirm{% endtrans %}
-              {% if has_remaining_forms or is_contact_page %}
-                </span>
-              {% else %}
-                </a>
-              {% endif %}
-            </li>
-            <li class="progress-step {% if is_contact_page %}current-step{% endif %}">
-              <span class="step-name">
-                {{ step_status(false, is_contact_page) }}
-                {% trans %}Contact information{% endtrans %}
-              </span>
-            </li>
         </ul>
     </div>
 {% endmacro %}

--- a/app/templates/means_test/components/progress-bar.html
+++ b/app/templates/means_test/components/progress-bar.html
@@ -1,9 +1,9 @@
-{% macro progress_bar(completed, offset=-2) %}
+{% macro progress_bar(completed) %}
   {% if completed is number %}
     {# This is a workaround to avoid using inline styles, as nonces can only be applied to script/ style tags #}
     <style nonce="{{ csp_nonce() }}">
       .progress-value {
-        width: {{ completed + offset }}%;
+        width: {{ completed }}%;
       }
     </style>
     <div class="progress-bar">

--- a/app/templates/means_test/components/progress-bar.html
+++ b/app/templates/means_test/components/progress-bar.html
@@ -37,7 +37,7 @@
             {# Steps to do #}
             {% for step in steps %}
                 {# Optional collapsed steps #}
-                {% if not is_about_you_complete and step.title == "Check your answer and confirm" %}
+                {% if not is_about_you_complete and step.key == "review" %}
                   <li class="progress-step m-collapsed">
                     {% for n in range(3) %}
                       <div class="step-name"></div>

--- a/app/templates/means_test/review.html
+++ b/app/templates/means_test/review.html
@@ -2,6 +2,7 @@
 {%- from 'components/back_link.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/exit-this-page/macro.html' import govukExitThisPage -%}
 {%- from 'govuk_frontend_jinja/components/summary-list/macro.html' import govukSummaryList -%}
+{%- from 'means_test/components/progress-bar.html' import progress as means_test_progress %}
 {% set title = _("Check your answers and confirm") %}
 {% block pageTitle %}{{ title }} - GOV.UK{% endblock %}
 
@@ -73,6 +74,11 @@
             </form>
         {% endblock %}
 
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <aside class="sidebar">
+            {{ means_test_progress(form_progress["steps"], form_progress["current_step"], form_progress["completion_percentage"]) }}
+        </aside>
     </div>
 </div>
 {% endblock %}

--- a/tests/functional_tests/means_test/test_progress.py
+++ b/tests/functional_tests/means_test/test_progress.py
@@ -40,6 +40,34 @@ def fill_in_full_about_you_form(page: Page):
     page.get_by_role("button", name="Continue").click()
 
 
+def fill_in_minimal_about_you_form(page: Page):
+    page.locator("#has_partner-2").check()
+    page.get_by_role("group", name="Do you receive any benefits (").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("group", name="Do you have any children aged").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("group", name="Do you have any dependants").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("group", name="Do you own any property?").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("group", name="Are you employed?").get_by_label("No").check()
+    page.get_by_role("group", name="Are you self-employed?").get_by_label("No").check()
+    page.get_by_role("group", name="Are you or your partner (if").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("group", name="Do you have any savings or").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("group", name="Do you have any valuable").get_by_label(
+        "No"
+    ).check()
+    page.get_by_role("button", name="Continue").click()
+
+
 @pytest.mark.usefixtures("live_server")
 @pytest.mark.usefixtures("navigate_to_means_test")
 def test_progress_component_full(page: Page):
@@ -132,3 +160,18 @@ def test_progress_component_collapsed_steps(page: Page):
         .locator("div")
         .nth(2)
     ).not_to_be_visible()
+
+
+@pytest.mark.usefixtures("live_server")
+@pytest.mark.usefixtures("navigate_to_means_test")
+def test_progress_bar_review_answers_and_contact(page: Page):
+    fill_in_minimal_about_you_form(page)
+    page.get_by_role("group", name="Maintenance received").get_by_label("Amount").fill(
+        "0"
+    )
+    page.get_by_role("group", name="Pension received").get_by_label("Amount").fill("0")
+    page.get_by_role("group", name="Any other income").get_by_label("Amount").fill("0")
+    page.get_by_role("button", name="Continue").click()
+    expect(page.get_by_text("Current page: Check your answers")).to_be_visible()
+    page.get_by_role("button", name="Continue").click()
+    expect(page.get_by_text("Current page: Contact information")).to_be_visible()

--- a/tests/unit_tests/means_test/test_form_progress.py
+++ b/tests/unit_tests/means_test/test_form_progress.py
@@ -59,8 +59,8 @@ class TestGetFormProgress:
             ("about-you", set(), 12.5),  # 1/8 * 100
             ("benefits", {"about-you"}, 25),  # 2/8 * 100
             (
-                "savings",
-                {"about-you", "benefits", "additional-benefits", "property", "income"},
+                "income",
+                {"about-you", "benefits", "additional-benefits", "property", "savings"},
                 75,
             ),  # 6/8 * 100
         ],
@@ -82,7 +82,7 @@ class TestGetFormProgress:
     @pytest.mark.parametrize(
         "visible_forms,expected_steps",
         [
-            # Test different combinations of visible forms
+            # Test different combinations of visible forms, the review and contact page are included by default.
             (
                 {
                     "about-you",
@@ -92,11 +92,11 @@ class TestGetFormProgress:
                     "savings",
                     "income",
                 },
-                6,
+                8,
             ),
-            ({"about-you", "property", "savings", "income", "additional-benefits"}, 5),
-            ({"about-you", "property", "savings", "income"}, 4),
-            ({"about-you"}, 1),
+            ({"about-you", "property", "savings", "income", "additional-benefits"}, 7),
+            ({"about-you", "property", "savings", "income"}, 6),
+            ({"about-you"}, 3),
         ],
     )
     def test_visible_steps(self, view, visible_forms, expected_steps):
@@ -135,4 +135,7 @@ class TestGetFormProgress:
         with patch.object(MeansTest, "is_form_completed", return_value=False):
             result = test_view.get_form_progress(forms["about-you"]())
             for step in result["steps"]:
-                assert step["url"] == url_for(f"means_test.{step['key']}")
+                expected_route = f"means_test.{step['key']}"
+                if step["key"] == "contact-us":
+                    expected_route = "contact.contact_us"
+                assert step["url"] == url_for(expected_route)

--- a/tests/unit_tests/means_test/test_form_submission.py
+++ b/tests/unit_tests/means_test/test_form_submission.py
@@ -75,6 +75,10 @@ class TestDispatchRequest:
             patch("app.means_test.views.is_eligible") as mock_is_eligible,
             patch("app.means_test.views.MeansTestPayload") as mock_payload_class,
             patch("app.means_test.views.redirect") as mock_redirect,
+            patch(
+                "app.means_test.views.MeansTest.ensure_form_protection",
+                return_value=None,
+            ),
         ):
             mock_payload = mock_payload_class.return_value
             mock_update_means_test.return_value = {"reference": "test-reference"}
@@ -118,6 +122,10 @@ class TestDispatchRequest:
             patch("app.means_test.views.is_eligible") as mock_is_eligible,
             patch("app.means_test.views.MeansTestPayload"),
             patch("app.means_test.views.redirect") as mock_redirect,
+            patch(
+                "app.means_test.views.MeansTest.ensure_form_protection",
+                return_value=None,
+            ),
         ):
             mock_update_means_test.return_value = {"reference": "test-reference"}
             mock_is_eligible.return_value = EligibilityState.YES
@@ -146,6 +154,10 @@ class TestDispatchRequest:
             patch("app.means_test.views.SavingsForm", return_value=mock_form),
             patch("app.means_test.views.update_means_test") as mock_update_means_test,
             patch("app.means_test.views.MeansTestPayload"),
+            patch(
+                "app.means_test.views.MeansTest.ensure_form_protection",
+                return_value=None,
+            ),
         ):
             mock_update_means_test.return_value = {}
 


### PR DESCRIPTION
## What does this pull request do?

### Fixes an issue where changing an answer would allow you to skip ahead to future forms via the progress bar
- Now the progress bar only allows you to navigate backwards and all forms need to be completed in order

### Adds the progress bar to the 'Check your answers' page
- This page was previously missing this component

### Fixes an issue where the review/ contact steps were not showing as 'active'/ 'complete'

### Removes forms that the user was not asked to complete from the progress bar
- If the user is deemed eligible/ ineligible without completing a page then the page will be appropriately removed from the progress component

https://github.com/user-attachments/assets/ec3bf338-4634-4be9-9031-3e5a288e820d

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
