### PR TITLE
LGA-3759: Fix rebrand not applying automatically

### DIFF
--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,7 +1,6 @@
 import os
 from dotenv import load_dotenv
 from datetime import timedelta
-import datetime
 
 # Allows .env to be used in project for local development.
 load_dotenv()
@@ -38,4 +37,3 @@ class Config(object):
     SESSION_COOKIE_SECURE = True
     OS_PLACES_API_KEY = os.environ.get("OS_PLACES_API_KEY")
     EMAIL_ORCHESTRATOR_URL = os.environ.get("EMAIL_ORCHESTRATOR_URL")
-    GOVUK_REBRAND = datetime.datetime.now() > datetime.datetime(2025, 6, 25)

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -74,8 +74,3 @@ def inject_govuk_rebrand():
         )
 
     return {"GOVUK_REBRAND_ENABLED": govuk_rebrand_enabled}
-
-
-@bp.app_context_processor
-def inject_time():
-    return {"TIME": datetime.now()}

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flask import Blueprint, request, url_for, session
 from flask import current_app
 
@@ -59,3 +60,22 @@ def inject_exit_this_page():
 @bp.app_context_processor
 def inject_risk_of_harm():
     return {"at_risk_of_harm": session.at_risk_of_harm()}
+
+
+@bp.app_context_processor
+def inject_govuk_rebrand():
+    govuk_rebrand_enabled = datetime.now() > datetime(2025, 6, 25)
+    if (
+        not govuk_rebrand_enabled
+        and current_app.config.get("ENVIRONMENT") != "production"
+    ):
+        govuk_rebrand_enabled = (
+            request.args.get("govuk_rebrand_enabled", "false").lower() == "true"
+        )
+
+    return {"GOVUK_REBRAND_ENABLED": govuk_rebrand_enabled}
+
+
+@bp.app_context_processor
+def inject_time():
+    return {"TIME": datetime.now()}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,6 +1,6 @@
 {%  set htmlLang = language.current %}
 {%  set cspNonce = csp_nonce() %}
-{%  set govukRebrand = config['GOVUK_REBRAND'] %}
+{%  set govukRebrand = GOVUK_REBRAND_ENABLED %}
 {% set htmlClasses = "govuk-environment-" + config["ENVIRONMENT"] %}
 {% extends 'govuk_frontend_jinja/template.html' %}
 
@@ -137,6 +137,7 @@
 {% endblock %}
 
 {% block header %}
+    {{ TIME }}
   {{ govukHeader({
         'homepageUrl': "https://www.gov.uk",
         'serviceName': config['SERVICE_NAME'] if not govukRebrand,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -137,7 +137,6 @@
 {% endblock %}
 
 {% block header %}
-    {{ TIME }}
   {{ govukHeader({
         'homepageUrl': "https://www.gov.uk",
         'serviceName': config['SERVICE_NAME'] if not govukRebrand,


### PR DESCRIPTION
## What does this pull request do?

- Checks current time on each new request rather than during app startup so the rebrand will automatically be applied from the 25th of June 2025.
- Adds support for the `govuk-rebrand-enabled` query string, as was done for FALA.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
