### PR TITLE
LGA-3962: upgrade govuk-frontend to match frontend-jinja supported version

### DIFF
--- a/app/static/src/scss/styles.scss
+++ b/app/static/src/scss/styles.scss
@@ -1,5 +1,5 @@
 /* Import GOVUK frontend SCSS to be compiled to CSS */
-@import "govuk-frontend/dist/govuk/all.scss";
+@import "govuk-frontend/dist/govuk/index.scss";
 
 
 /* Import your custom SCSS below to be compiled into one by Flask Assets */

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "govuk-frontend": "^5.14.0"
+        "govuk-frontend": "6.0.0"
       },
       "devDependencies": {
         "esbuild": "0.27.4",
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.0.0.tgz",
+      "integrity": "sha512-n1DUbQD6coHL3UkQS0yTbd4ziIxLBzkWBODVCjXMclSY7FvOGeHcTg3c72z6u7DQECQb0tfZofhPjGxPUOIizA==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "npm run gov-images && node esbuild.config.js --watch"
   },
   "dependencies": {
-    "govuk-frontend": "^5.14.0"
+    "govuk-frontend": "6.0.0"
   },
   "overrides": {
     "picomatch": "4.0.4"


### PR DESCRIPTION
## What does this pull request do?

`govuk-frontend-jinja` was updated to 4.x.x, which then requires `govuk-frontend` version 6.x.x

I have updated to 6.0.0 as it's the only supported one for now. This also change the import to `index.scss` 

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
