### PR TITLE
LGA-3946: make access primary host for check and remove canary

### DIFF
--- a/helm_deploy/laa-access-civil-legal-aid/values/values-staging.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-staging.yaml
@@ -7,12 +7,7 @@ ingress:
   tls:
     secretName: "tls-certificate"
   annotations:
-    allow-duplicate-host: "true"
-    nginx.ingress.kubernetes.io/canary: "true"
-    allowed-duplicate-ns: "laa-cla-public-staging,laa-access-civil-legal-aid-staging"
-    nginx.ingress.kubernetes.io/canary-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/canary-by-cookie: "canary"
     nginx.ingress.kubernetes.io/session-cookie-name: "ROUTE"
     nginx.ingress.kubernetes.io/session-cookie-path: "/"
     nginx.ingress.kubernetes.io/session-cookie-refresh: "true"


### PR DESCRIPTION
## What does this pull request do?

As part of decommissioning `laa-cla-public`, this PR removes the canary annotations from the `laa-access-civil-legal-aid` **staging** ingress, making it the primary host for [staging.checklegalaid.service.gov.uk](http://staging.checklegalaid.service.gov.uk/)

Previously, `laa-access-civil-legal-aid` was configured as a canary ingress with `laa-cla-public-staging` as the primary. While all traffic was already routing to the new app, nginx canary still requires the primary backend to have healthy endpoints, meaning `laa-cla-public-staging` pods had to stay running even though they were serving no traffic.

Merging this unblocks the deletion of the `laa-cla-public-staging` namespace. Production to follow once staging is confirmed stable. 

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
