### PR TITLE
LGA-3946: promote ingress to primary host so we can delete cla-public

### DIFF
--- a/helm_deploy/laa-access-civil-legal-aid/values/values-production.yaml
+++ b/helm_deploy/laa-access-civil-legal-aid/values/values-production.yaml
@@ -7,12 +7,7 @@ ingress:
   tls:
     secretName: "tls-certificate"
   annotations:
-    allow-duplicate-host: "true"
-    nginx.ingress.kubernetes.io/canary: "true"
-    allowed-duplicate-ns: "laa-cla-public-production,laa-access-civil-legal-aid-production"
-    nginx.ingress.kubernetes.io/canary-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/canary-by-cookie: "canary"
     nginx.ingress.kubernetes.io/session-cookie-name: "ROUTE"
     nginx.ingress.kubernetes.io/session-cookie-path: "/"
     nginx.ingress.kubernetes.io/session-cookie-refresh: "true"


### PR DESCRIPTION
## What does this pull request do?

Following promotion of `laa-access-civil-legal-aid-staging` to primary host, and successful deprecation of cla-public-staging, I am proceeding to do the same with production. 

- [x] promote access production host 
- [ ] delete namespace via Cloud Platform

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
