### PR TITLE
LGA-4151: add validators to form and sanitise data in email personalisation

### DIFF
--- a/app/contact/forms.py
+++ b/app/contact/forms.py
@@ -235,7 +235,7 @@ class ContactUsForm(FlaskForm):
         _("Your full name"),
         widget=GovTextInput(),
         validators=[
-            Length(max=100, message=_("Your full name must be 100 characters or less")),
+            Length(max=255, message=_("Your full name must be 255 characters or less")),
             InputRequired(message=_("Tell us your name")),
             NoURLs(message=_("Enter a valid full name")),
         ],
@@ -322,7 +322,7 @@ class ContactUsForm(FlaskForm):
         widget=GovTextInput(),
         validators=[
             ValidateIf("contact_type", "thirdparty"),
-            Length(max=100, message=_("Their full name must be 100 characters or less")),
+            Length(max=255, message=_("Their full name must be 255 characters or less")),
             InputRequired(message=_("Tell us the name of the person to call")),
             NoURLs(message=_("Enter a valid full name")),
         ],

--- a/app/contact/forms.py
+++ b/app/contact/forms.py
@@ -34,7 +34,10 @@ from flask_babel import lazy_gettext as _
 from wtforms.validators import InputRequired, Length, Optional, Email
 from app.main import get_locale
 from app.contact.validators import (
+    NoURLs,
     ValidateDayTime,
+    ValidatePhoneNumber,
+    ValidatePostcode,
 )
 from app.means_test.validators import ValidateIf, ValidateIfType
 from app.api import cla_backend
@@ -232,8 +235,9 @@ class ContactUsForm(FlaskForm):
         _("Your full name"),
         widget=GovTextInput(),
         validators=[
-            Length(max=400, message=_("Your full name must be 400 characters or less")),
+            Length(max=100, message=_("Your full name must be 100 characters or less")),
             InputRequired(message=_("Tell us your name")),
+            NoURLs(message=_("Enter a valid full name")),
         ],
     )
 
@@ -252,6 +256,7 @@ class ContactUsForm(FlaskForm):
             ValidateIf("contact_type", "callback"),
             InputRequired(message=_("Tell us what number to ring")),
             Length(max=20, message=_("Your telephone number must be 20 characters or less")),
+            ValidatePhoneNumber(message=_("Enter a valid phone number")),
         ],
     )
 
@@ -317,8 +322,9 @@ class ContactUsForm(FlaskForm):
         widget=GovTextInput(),
         validators=[
             ValidateIf("contact_type", "thirdparty"),
-            Length(max=400, message=_("Their full name must be 400 characters or less")),
+            Length(max=100, message=_("Their full name must be 100 characters or less")),
             InputRequired(message=_("Tell us the name of the person to call")),
+            NoURLs(message=_("Enter a valid full name")),
         ],
     )
 
@@ -340,6 +346,7 @@ class ContactUsForm(FlaskForm):
             ValidateIf("contact_type", "thirdparty"),
             InputRequired(message=_("Tell us what number to ring")),
             Length(max=20, message=_("Your telephone number must be 20 characters or less")),
+            ValidatePhoneNumber(message=_("Enter a valid phone number")),
         ],
     )
 
@@ -410,6 +417,10 @@ class ContactUsForm(FlaskForm):
     post_code = StringField(
         _("Postcode (optional)"),
         widget=GovTextInput(),
+        validators=[
+            Optional(),
+            ValidatePostcode(message=_("Enter a valid postcode")),
+        ],
     )
     address_finder = SelectField(_("Select an address"), choices=[""], widget=GovSelect(), validate_choice=False)
     street_address = TextAreaField(
@@ -418,6 +429,7 @@ class ContactUsForm(FlaskForm):
         validators=[
             Length(max=255, message=_("Your address must be 255 characters or less")),
             Optional(),
+            NoURLs(message=_("Enter a valid street address")),
         ],
     )
 
@@ -427,6 +439,7 @@ class ContactUsForm(FlaskForm):
         validators=[
             Length(max=4000, message=_("Your notes must be 4000 characters or less")),
             Optional(),
+            NoURLs(message=_("Do not include links in your notes")),
         ],
     )
 
@@ -472,6 +485,7 @@ class ContactUsForm(FlaskForm):
                 max=4000,
                 message=_("Your other communication needs must be 4000 characters or fewer"),
             ),
+            NoURLs(message=_("Do not include links in your communication needs")),
         ],
     )
 

--- a/app/contact/forms.py
+++ b/app/contact/forms.py
@@ -37,7 +37,6 @@ from app.contact.validators import (
     NoURLs,
     ValidateDayTime,
     ValidatePhoneNumber,
-    ValidatePostcode,
 )
 from app.means_test.validators import ValidateIf, ValidateIfType
 from app.api import cla_backend
@@ -419,7 +418,8 @@ class ContactUsForm(FlaskForm):
         widget=GovTextInput(),
         validators=[
             Optional(),
-            ValidatePostcode(message=_("Enter a valid postcode")),
+            Length(max=12, message=_("Enter a valid postcode")),
+            NoURLs(message=_("Enter a valid postcode")),
         ],
     )
     address_finder = SelectField(_("Select an address"), choices=[""], widget=GovSelect(), validate_choice=False)

--- a/app/contact/notify/api.py
+++ b/app/contact/notify/api.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from app import get_locale
 from app.contact.notify.templates import GOVUK_NOTIFY_TEMPLATES
 from app.contact.helpers import format_callback_time
+from app.contact.validators import sanitise_personalisation
 
 logger = logging.getLogger(__name__)
 
@@ -121,8 +122,8 @@ class NotifyEmailOrchestrator(object):
             return template_id, personalisation
 
         personalisation = {
-            "full_name": full_name,
-            "thirdparty_full_name": third_party_name,
+            "full_name": sanitise_personalisation(full_name),
+            "thirdparty_full_name": sanitise_personalisation(third_party_name),
             "case_reference": case_reference,
             "date_time": formatted_callback_time,
         }
@@ -134,10 +135,10 @@ class NotifyEmailOrchestrator(object):
         # Decides between a personal callback or a third party callback
         if phone_number:
             template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_WITH_NUMBER"][locale]
-            personalisation.update(contact_number=phone_number)
+            personalisation.update(contact_number=sanitise_personalisation(phone_number))
         elif third_party_phone_number:
             template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_THIRD_PARTY"][locale]
-            personalisation.update(contact_number=third_party_phone_number)
+            personalisation.update(contact_number=sanitise_personalisation(third_party_phone_number))
 
         return template_id, personalisation
 

--- a/app/contact/validators.py
+++ b/app/contact/validators.py
@@ -69,13 +69,3 @@ class ValidatePhoneNumber:
         digits = re.sub(r"\D", "", field.data)
         if not (7 <= len(digits) <= 15):
             raise ValidationError(self.message)
-
-
-class ValidatePostcode:
-    def __init__(self, message=None):
-        self.message = message or "Enter a valid postcode"
-        self._pattern = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}$", re.IGNORECASE)
-
-    def __call__(self, form, field):
-        if field.data and not self._pattern.match(field.data.strip()):
-            raise ValidationError(self.message)

--- a/app/contact/validators.py
+++ b/app/contact/validators.py
@@ -1,5 +1,23 @@
+import logging
+import re
+
 from wtforms.validators import ValidationError
 from wtforms.validators import StopValidation
+
+logger = logging.getLogger(__name__)
+
+_URL_PATTERN = re.compile(r"https?://|www\.|/", re.IGNORECASE)
+
+
+def sanitise_personalisation(value: str | None) -> str | None:
+    """Strip whitespace and reject values containing URLs before sending to gov-notify."""
+    if not value:
+        return value
+    value = value.strip()
+    if _URL_PATTERN.search(value):
+        logger.warning("Unsafe personalisation value blocked: %s", value[:50])
+        return None
+    return value
 
 
 class ValidateDayTime:
@@ -26,3 +44,38 @@ class ValidateDayTime:
                 raise StopValidation()
 
         raise ValidationError(self.message)
+
+
+class NoURLs:
+    def __init__(self, message=None):
+        self.message = message or "Enter a valid name"
+        self._pattern = re.compile(r"https?://|www\.|/", re.IGNORECASE)
+
+    def __call__(self, form, field):
+        if field.data and self._pattern.search(field.data):
+            raise ValidationError(self.message)
+
+
+class ValidatePhoneNumber:
+    def __init__(self, message=None):
+        self.message = message or "Enter a valid phone number"
+        self._allowed = re.compile(r"^[0-9+\s\-()\[\]]+$")
+
+    def __call__(self, form, field):
+        if not field.data:
+            return
+        if not self._allowed.match(field.data):
+            raise ValidationError(self.message)
+        digits = re.sub(r"\D", "", field.data)
+        if not (7 <= len(digits) <= 15):
+            raise ValidationError(self.message)
+
+
+class ValidatePostcode:
+    def __init__(self, message=None):
+        self.message = message or "Enter a valid postcode"
+        self._pattern = re.compile(r"^[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}$", re.IGNORECASE)
+
+    def __call__(self, form, field):
+        if field.data and not self._pattern.match(field.data.strip()):
+            raise ValidationError(self.message)

--- a/app/contact/validators.py
+++ b/app/contact/validators.py
@@ -49,10 +49,9 @@ class ValidateDayTime:
 class NoURLs:
     def __init__(self, message=None):
         self.message = message or "Enter a valid name"
-        self._pattern = re.compile(r"https?://|www\.|/", re.IGNORECASE)
 
     def __call__(self, form, field):
-        if field.data and self._pattern.search(field.data):
+        if field.data and _URL_PATTERN.search(field.data):
             raise ValidationError(self.message)
 
 

--- a/app/contact/validators.py
+++ b/app/contact/validators.py
@@ -6,13 +6,13 @@ from wtforms.validators import StopValidation
 
 logger = logging.getLogger(__name__)
 
-_URL_PATTERN = re.compile(r"https?://|www\.|/", re.IGNORECASE)
+_URL_PATTERN = re.compile(r"(https?://|www\.|\b[a-z0-9.-]+\.[a-z]{2,}(?:/\S*)?)", re.IGNORECASE)
 
 
 def sanitise_personalisation(value: str | None) -> str | None:
     """Strip whitespace and reject values containing URLs before sending to gov-notify."""
     if not value:
-        return value
+        return
     value = value.strip()
     if _URL_PATTERN.search(value):
         logger.warning("Unsafe personalisation value blocked: %s", value[:50])

--- a/tests/functional_tests/contact/test_confirmation.py
+++ b/tests/functional_tests/contact/test_confirmation.py
@@ -81,7 +81,7 @@ def test_thirdparty_callback(page: Page):
     page.get_by_role("radio", name="Call someone else instead of").check()
     page.get_by_role("textbox", name="Full name of the person to").fill("Jane Doe")
     page.get_by_label("Relationship to you").select_option("family_friend")
-    page.get_by_role("textbox", name="Phone number").fill("12345")
+    page.get_by_role("textbox", name="Phone number").fill("07700900000")
     page.get_by_role("radio", name="Call on another day").check()
     page.locator("#thirdparty_call_another_day").select_option(index=1)
     page.locator("#thirdparty_call_another_time").select_option(index=1)

--- a/tests/unit_tests/contact/test_contact.py
+++ b/tests/unit_tests/contact/test_contact.py
@@ -12,6 +12,7 @@ from wtforms import Form, StringField
 from wtforms.validators import ValidationError, StopValidation
 from app.contact.validators import ValidateDayTime
 from freezegun import freeze_time
+from werkzeug.datastructures import MultiDict
 
 
 def test_post_reasons_for_contacting_success(mocker, app):
@@ -440,3 +441,170 @@ class TestCallbackTimeFunctions:
         test_time = datetime(2024, 1, 1, 23, 45)
         result = format_callback_time(test_time)
         assert result == "Monday, 1 January at 23:45 - 00:15"
+
+
+# ContactUsForm field validation
+
+
+def make_contact_form(app, data):
+    pairs = []
+    for key, value in data.items():
+        if isinstance(value, list):
+            for v in value:
+                pairs.append((key, v))
+        else:
+            pairs.append((key, value))
+
+    with app.app_context():
+        with patch("app.contact.forms.cla_backend"):
+            form = ContactUsForm(formdata=MultiDict(pairs))
+            form.validate()
+            return form
+
+
+class TestFullName:
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"full_name": "https://evil.com"})
+        assert "full_name" in form.errors
+
+    def test_rejects_path(self, app):
+        form = make_contact_form(app, {"full_name": "evil.com/admin"})
+        assert "full_name" in form.errors
+
+    def test_rejects_too_long(self, app):
+        form = make_contact_form(app, {"full_name": "A" * 101})
+        assert "full_name" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"full_name": "Mary-Jane O'Brien"})
+        assert "full_name" not in form.errors
+
+    def test_accepts_international(self, app):
+        form = make_contact_form(app, {"full_name": "José Müller"})
+        assert "full_name" not in form.errors
+
+
+class TestThirdPartyFullName:
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_full_name": "https://evil.com"})
+        assert "thirdparty_full_name" in form.errors
+
+    def test_rejects_too_long(self, app):
+        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_full_name": "A" * 101})
+        assert "thirdparty_full_name" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_full_name": "John Smith"})
+        assert "thirdparty_full_name" not in form.errors
+
+
+class TestContactNumber:
+    def test_rejects_non_numeric(self, app):
+        form = make_contact_form(app, {"contact_type": "callback", "contact_number": "not-a-number"})
+        assert "contact_number" in form.errors
+
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"contact_type": "callback", "contact_number": "https://evil.com"})
+        assert "contact_number" in form.errors
+
+    def test_rejects_too_short(self, app):
+        form = make_contact_form(app, {"contact_type": "callback", "contact_number": "123"})
+        assert "contact_number" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"contact_type": "callback", "contact_number": "07911 123456"})
+        assert "contact_number" not in form.errors
+
+    def test_accepts_international(self, app):
+        form = make_contact_form(app, {"contact_type": "callback", "contact_number": "+44 7911 123456"})
+        assert "contact_number" not in form.errors
+
+
+class TestThirdPartyContactNumber:
+    def test_rejects_non_numeric(self, app):
+        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_contact_number": "not-a-number"})
+        assert "thirdparty_contact_number" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_contact_number": "07911 123456"})
+        assert "thirdparty_contact_number" not in form.errors
+
+
+class TestEmail:
+    def test_rejects_invalid_format(self, app):
+        form = make_contact_form(app, {"email": "not-an-email"})
+        assert "email" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"email": "user@example.com"})
+        assert "email" not in form.errors
+
+    def test_accepts_empty(self, app):
+        form = make_contact_form(app, {"email": ""})
+        assert "email" not in form.errors
+
+
+class TestPostCode:
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"post_code": "https://evil.com"})
+        assert "post_code" in form.errors
+
+    def test_rejects_invalid(self, app):
+        form = make_contact_form(app, {"post_code": "NOTAPOSTCODE"})
+        assert "post_code" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"post_code": "SW1A 1AA"})
+        assert "post_code" not in form.errors
+
+    def test_accepts_empty(self, app):
+        form = make_contact_form(app, {"post_code": ""})
+        assert "post_code" not in form.errors
+
+
+class TestStreetAddress:
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"street_address": "https://evil.com"})
+        assert "street_address" in form.errors
+
+    def test_rejects_too_long(self, app):
+        form = make_contact_form(app, {"street_address": "A" * 256})
+        assert "street_address" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"street_address": "123 Example Street"})
+        assert "street_address" not in form.errors
+
+    def test_accepts_empty(self, app):
+        form = make_contact_form(app, {"street_address": ""})
+        assert "street_address" not in form.errors
+
+
+class TestExtraNotes:
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"extra_notes": "check out https://evil.com"})
+        assert "extra_notes" in form.errors
+
+    def test_rejects_too_long(self, app):
+        form = make_contact_form(app, {"extra_notes": "A" * 4001})
+        assert "extra_notes" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(app, {"extra_notes": "I need help with my housing issue"})
+        assert "extra_notes" not in form.errors
+
+    def test_accepts_empty(self, app):
+        form = make_contact_form(app, {"extra_notes": ""})
+        assert "extra_notes" not in form.errors
+
+
+class TestOtherAdaptation:
+    def test_rejects_url(self, app):
+        form = make_contact_form(app, {"adaptations": ["other_adaptation"], "other_adaptation": "https://evil.com"})
+        assert "other_adaptation" in form.errors
+
+    def test_accepts_valid(self, app):
+        form = make_contact_form(
+            app, {"adaptations": ["other_adaptation"], "other_adaptation": "Large print documents"}
+        )
+        assert "other_adaptation" not in form.errors

--- a/tests/unit_tests/contact/test_contact.py
+++ b/tests/unit_tests/contact/test_contact.py
@@ -549,12 +549,16 @@ class TestPostCode:
         form = make_contact_form(app, {"post_code": "https://evil.com"})
         assert "post_code" in form.errors
 
-    def test_rejects_invalid(self, app):
-        form = make_contact_form(app, {"post_code": "NOTAPOSTCODE"})
+    def test_rejects_too_long(self, app):
+        form = make_contact_form(app, {"post_code": "A" * 11})
         assert "post_code" in form.errors
 
-    def test_accepts_valid(self, app):
+    def test_accepts_full_postcode(self, app):
         form = make_contact_form(app, {"post_code": "SW1A 1AA"})
+        assert "post_code" not in form.errors
+
+    def test_accepts_partial_postcode(self, app):
+        form = make_contact_form(app, {"post_code": "SW1"})
         assert "post_code" not in form.errors
 
     def test_accepts_empty(self, app):

--- a/tests/unit_tests/contact/test_contact.py
+++ b/tests/unit_tests/contact/test_contact.py
@@ -472,7 +472,7 @@ class TestFullName:
         assert "full_name" in form.errors
 
     def test_rejects_too_long(self, app):
-        form = make_contact_form(app, {"full_name": "A" * 101})
+        form = make_contact_form(app, {"full_name": "A" * 256})
         assert "full_name" in form.errors
 
     def test_accepts_valid(self, app):
@@ -490,7 +490,7 @@ class TestThirdPartyFullName:
         assert "thirdparty_full_name" in form.errors
 
     def test_rejects_too_long(self, app):
-        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_full_name": "A" * 101})
+        form = make_contact_form(app, {"contact_type": "thirdparty", "thirdparty_full_name": "A" * 256})
         assert "thirdparty_full_name" in form.errors
 
     def test_accepts_valid(self, app):

--- a/tests/unit_tests/contact/test_contact.py
+++ b/tests/unit_tests/contact/test_contact.py
@@ -550,7 +550,7 @@ class TestPostCode:
         assert "post_code" in form.errors
 
     def test_rejects_too_long(self, app):
-        form = make_contact_form(app, {"post_code": "A" * 11})
+        form = make_contact_form(app, {"post_code": "A" * 13})
         assert "post_code" in form.errors
 
     def test_accepts_full_postcode(self, app):

--- a/tests/unit_tests/contact/test_notify.py
+++ b/tests/unit_tests/contact/test_notify.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 from app.contact.notify.api import NotifyEmailOrchestrator, notify
+from app.contact.validators import sanitise_personalisation
 from datetime import datetime
 
 
@@ -273,3 +274,90 @@ def test_generate_confirmation_email_data(input_data, expected_template_id, expe
 
         assert template_id == expected_template_id
         assert personalisation == expected_personalisation
+
+
+# Sanitisation of personalisation fields
+
+
+class TestSanitisePersonalisation:
+    def test_strips_whitespace(self):
+        assert sanitise_personalisation("  John Smith  ") == "John Smith"
+
+    def test_passes_through_clean_value(self):
+        assert sanitise_personalisation("John Smith") == "John Smith"
+
+    def test_returns_none_for_none(self):
+        assert sanitise_personalisation(None) is None
+
+    def test_blocks_https_url(self):
+        assert sanitise_personalisation("https://evil.com") is None
+
+    def test_blocks_http_url(self):
+        assert sanitise_personalisation("http://evil.com") is None
+
+    def test_blocks_www(self):
+        assert sanitise_personalisation("www.evil.com") is None
+
+    def test_blocks_path(self):
+        assert sanitise_personalisation("evil.com/admin") is None
+
+
+class TestPersonalisationSanitisedInEmail:
+    def _generate(self, **kwargs):
+        with (
+            patch("app.contact.notify.api.get_locale", return_value="en"),
+            patch("app.contact.notify.api.format_callback_time", return_value="formatted-time"),
+            patch("app.contact.notify.api.GOVUK_NOTIFY_TEMPLATES", MOCK_GOVUK_NOTIFY_TEMPLATES),
+        ):
+            return notify.generate_confirmation_email_data(**kwargs)
+
+    def test_url_in_full_name_is_blocked(self):
+        _, personalisation = self._generate(
+            case_reference="AB-1234-5678",
+            callback_time=None,
+            contact_type=None,
+            full_name="https://evil.com",
+            third_party_name=None,
+            phone_number=None,
+            third_party_phone_number=None,
+        )
+        assert personalisation["full_name"] is None
+
+    def test_url_in_thirdparty_name_is_blocked(self):
+        _, personalisation = self._generate(
+            case_reference="AB-1234-5678",
+            callback_time=None,
+            contact_type=None,
+            full_name="John Smith",
+            third_party_name="https://evil.com",
+            phone_number=None,
+            third_party_phone_number=None,
+        )
+        assert personalisation["thirdparty_full_name"] is None
+
+    def test_url_in_phone_number_is_blocked(self):
+        from datetime import datetime
+
+        _, personalisation = self._generate(
+            case_reference="AB-1234-5678",
+            callback_time=datetime(2025, 1, 1, 12, 0),
+            contact_type="callback",
+            full_name="John Smith",
+            third_party_name=None,
+            phone_number="https://evil.com",
+            third_party_phone_number=None,
+        )
+        assert personalisation["contact_number"] is None
+
+    def test_clean_values_pass_through(self):
+        _, personalisation = self._generate(
+            case_reference="AB-1234-5678",
+            callback_time=None,
+            contact_type=None,
+            full_name="John Smith",
+            third_party_name="Jane Doe",
+            phone_number=None,
+            third_party_phone_number=None,
+        )
+        assert personalisation["full_name"] == "John Smith"
+        assert personalisation["thirdparty_full_name"] == "Jane Doe"


### PR DESCRIPTION
## What does this pull request do?

Ticket: https://dsdmoj.atlassian.net/browse/LGA-4151

Added new validators:
`NoURLs`
`ValidatePhoneNumber`

and apply those to the `/contact/form.py`

Also added `sanitise_personalisation` so the input data being sent to the Notify service is sanitised (no URLs and no whitespaces)

**Note**: Phone numbers allow up to 20 chars, but only 15 digits given the `ITU-T E.164 international maximum`

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
